### PR TITLE
Changed the version to a shields.io badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 :rocket: **This is the new official repository of the Hardcodet WPF NotifyIcon** :rocket:
 
-Current version: 1.0.8
-https://www.nuget.org/packages/Hardcodet.NotifyIcon.Wpf/
+Current version: [![Nuget](https://img.shields.io/nuget/v/Hardcodet.NotifyIcon.Wpf.svg)](https://www.nuget.org/packages/Hardcodet.NotifyIcon.Wpf/)
 
 ## Description
 


### PR DESCRIPTION
This looks nicer and as it's rendered at view time it will always represent the current version without changing the readme