### PR TITLE
Code modernising

### DIFF
--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/AppBarInfo.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/AppBarInfo.cs
@@ -6,60 +6,6 @@ using System.Runtime.InteropServices;
 
 namespace Hardcodet.Wpf.TaskbarNotification.Interop
 {
-    /// <summary>
-    /// Resolves the current tray position.
-    /// </summary>
-    public static class TrayInfo
-    {
-        /// <summary>
-        /// Gets the position of the system tray.
-        /// </summary>
-        /// <returns>Tray coordinates.</returns>
-        public static Point GetTrayLocation()
-        {
-            int space = 2;
-            var info = new AppBarInfo();
-            info.GetSystemTaskBarPosition();
-
-            Rectangle rcWorkArea = info.WorkArea;
-
-            int x = 0, y = 0;
-            switch (info.Edge)
-            {
-                case AppBarInfo.ScreenEdge.Left:
-                    x = rcWorkArea.Right + space;
-                    y = rcWorkArea.Bottom;
-                    break;
-                case AppBarInfo.ScreenEdge.Bottom:
-                    x = rcWorkArea.Right;
-                    y = rcWorkArea.Bottom - rcWorkArea.Height - space;
-                    break;
-                case AppBarInfo.ScreenEdge.Top:
-                    x = rcWorkArea.Right;
-                    y = rcWorkArea.Top + rcWorkArea.Height + space;
-                    break;
-                case AppBarInfo.ScreenEdge.Right:
-                    x = rcWorkArea.Right - rcWorkArea.Width - space;
-                    y = rcWorkArea.Bottom;
-                    break;
-            }
-
-            return GetDeviceCoordinates(new Point {X = x, Y = y});
-        }
-
-        /// <summary>
-        /// Recalculates OS coordinates in order to support WPFs coordinate
-        /// system if OS scaling (DPIs) is not 100%.
-        /// </summary>
-        /// <param name="point"></param>
-        /// <returns></returns>
-        public static Point GetDeviceCoordinates(Point point)
-        {
-          return new Point() { X = (int)(point.X / SystemInfo.DpiXFactor), Y = (int)(point.Y / SystemInfo.DpiYFactor) };
-        }
-    }
-
-
     public class AppBarInfo
     {
         [DllImport("user32.dll")]
@@ -92,7 +38,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
 
         public Rectangle WorkArea
         {
-          get { return GetRectangle(m_data.rc); }
+            get { return GetRectangle(m_data.rc); }
         }
 
         private Rectangle GetRectangle(RECT rc)
@@ -149,6 +95,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
             public RECT rc;
             public int lParam;
         }
+
 
         [StructLayout(LayoutKind.Sequential)]
         private struct RECT

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/BalloonFlags.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/BalloonFlags.cs
@@ -6,7 +6,6 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
     /// Flags that define the icon that is shown on a balloon
     /// tooltip.
     /// </summary>
-    [Flags]
     public enum BalloonFlags
     {
         /// <summary>

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/BalloonFlags.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/BalloonFlags.cs
@@ -1,9 +1,12 @@
+using System;
+
 namespace Hardcodet.Wpf.TaskbarNotification.Interop
 {
     /// <summary>
     /// Flags that define the icon that is shown on a balloon
     /// tooltip.
     /// </summary>
+    [Flags]
     public enum BalloonFlags
     {
         /// <summary>

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/NotifyIconData.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/NotifyIconData.cs
@@ -56,7 +56,8 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// the terminating NULL. For Version 5.0 and later, szTip can have a maximum of
         /// 128 characters, including the terminating NULL.
         /// </summary>
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)] public string ToolTipText;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+        public string ToolTipText;
 
 
         /// <summary>
@@ -66,7 +67,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
 
         /// <summary>
         /// A value that specifies which bits of the state member are retrieved or modified.
-        /// For example, setting this member to <see cref="Interop.IconState.Hidden"/>
+        /// For example, setting this member to <see cref="TaskbarNotification.Interop.IconState.Hidden"/>
         /// causes only the item's hidden
         /// state to be retrieved.
         /// </summary>
@@ -76,12 +77,13 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// String with the text for a balloon ToolTip. It can have a maximum of 255 characters.
         /// To remove the ToolTip, set the NIF_INFO flag in uFlags and set szInfo to an empty string.
         /// </summary>
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)] public string BalloonText;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 256)]
+        public string BalloonText;
 
         /// <summary>
         /// Mainly used to set the version when <see cref="WinApi.Shell_NotifyIcon"/> is invoked
         /// with <see cref="NotifyCommand.SetVersion"/>. However, for legacy operations,
-        /// the same member is also used to set timouts for balloon ToolTips.
+        /// the same member is also used to set timeouts for balloon ToolTips.
         /// </summary>
         public uint VersionOrTimeout;
 
@@ -89,7 +91,8 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// String containing a title for a balloon ToolTip. This title appears in boldface
         /// above the text. It can have a maximum of 63 characters.
         /// </summary>
-        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)] public string BalloonTitle;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
+        public string BalloonTitle;
 
         /// <summary>
         /// Adds an icon to a balloon ToolTip, which is placed to the left of the title. If the
@@ -108,7 +111,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// <summary>
         /// Windows Vista (Shell32.dll version 6.0.6) and later. The handle of a customized
         /// balloon icon provided by the application that should be used independently
-        /// of the tray icon. If this member is non-NULL and the <see cref="Interop.BalloonFlags.User"/>
+        /// of the tray icon. If this member is non-NULL and the <see cref="TaskbarNotification.Interop.BalloonFlags.User"/>
         /// flag is set, this icon is used as the balloon icon.<br/>
         /// If this member is NULL, the legacy behavior is carried out.
         /// </summary>
@@ -157,7 +160,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                                 | IconDataMembers.Tip;
 
             //reset strings
-            data.ToolTipText = data.BalloonText = data.BalloonTitle = String.Empty;
+            data.ToolTipText = data.BalloonText = data.BalloonTitle = string.Empty;
 
             return data;
         }

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/NotifyIconData.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/NotifyIconData.cs
@@ -123,7 +123,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// a hidden taskbar icon without the icon being set.
         /// </summary>
         /// <param name="handle"></param>
-        /// <returns></returns>
+        /// <returns>NotifyIconData</returns>
         public static NotifyIconData CreateDefault(IntPtr handle)
         {
             var data = new NotifyIconData();

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/SystemInfo.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/SystemInfo.cs
@@ -2,41 +2,34 @@ using System.Windows.Interop;
 
 namespace Hardcodet.Wpf.TaskbarNotification.Interop
 {
+    /// <summary>
+    /// This class is a helper for system information, currently to get the DPI factors
+    /// </summary>
     public static class SystemInfo
     {
-        private static System.Windows.Point? dpiFactors;
+        private static readonly System.Windows.Point DpiFactors;
 
-        private static System.Windows.Point? DpiFactors
+        static SystemInfo()
         {
-            get
+            using (var source = new HwndSource(new HwndSourceParameters()))
             {
-                if (dpiFactors == null)
+                if (source.CompositionTarget?.TransformToDevice != null)
                 {
-                    using (var source = new HwndSource(new HwndSourceParameters()))
-                    {
-                        dpiFactors = new System.Windows.Point(source.CompositionTarget.TransformToDevice.M11, source.CompositionTarget.TransformToDevice.M22);
-                    }
+                    DpiFactors = new System.Windows.Point(source.CompositionTarget.TransformToDevice.M11, source.CompositionTarget.TransformToDevice.M22);
+                    return;
                 }
-                return dpiFactors;
+                DpiFactors = new System.Windows.Point(1, 1);
             }
         }
 
-        public static double DpiXFactor
-        {
-            get
-            {
-                var factors = DpiFactors;
-                return factors?.X ?? 1;
-            }
-        }
+        /// <summary>
+        /// Returns the DPI X Factor
+        /// </summary>
+        public static double DpiFactorX => DpiFactors.X;
 
-        public static double DpiYFactor
-        {
-            get
-            {
-                var factors = DpiFactors;
-                return factors?.Y ?? 1;
-            }
-        }
+        /// <summary>
+        /// Returns the DPI Y Factor
+        /// </summary>
+        public static double DpiFactorY => DpiFactors.Y;
     }
 }

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/SystemInfo.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/SystemInfo.cs
@@ -2,37 +2,41 @@ using System.Windows.Interop;
 
 namespace Hardcodet.Wpf.TaskbarNotification.Interop
 {
-  public static class SystemInfo
-  {
-    private static System.Windows.Point? dpiFactors;
-
-    private static System.Windows.Point? DpiFactors
+    public static class SystemInfo
     {
-      get
-      {
-        if (dpiFactors == null)        
-          using (var source = new HwndSource(new HwndSourceParameters()))
-            dpiFactors = new System.Windows.Point(source.CompositionTarget.TransformToDevice.M11, source.CompositionTarget.TransformToDevice.M22);        
-        return dpiFactors;
-      }
+        private static System.Windows.Point? dpiFactors;
+
+        private static System.Windows.Point? DpiFactors
+        {
+            get
+            {
+                if (dpiFactors == null)
+                {
+                    using (var source = new HwndSource(new HwndSourceParameters()))
+                    {
+                        dpiFactors = new System.Windows.Point(source.CompositionTarget.TransformToDevice.M11, source.CompositionTarget.TransformToDevice.M22);
+                    }
+                }
+                return dpiFactors;
+            }
+        }
+
+        public static double DpiXFactor
+        {
+            get
+            {
+                var factors = DpiFactors;
+                return factors?.X ?? 1;
+            }
+        }
+
+        public static double DpiYFactor
+        {
+            get
+            {
+                var factors = DpiFactors;
+                return factors?.Y ?? 1;
+            }
+        }
     }
-
-    public static double DpiXFactor
-    {
-      get
-      {
-        var factors = DpiFactors;
-        return factors.HasValue ? factors.Value.X : 1;
-      }
-    }
-
-    public static double DpiYFactor
-    {
-      get
-      {
-        var factors = DpiFactors;
-        return factors.HasValue ? factors.Value.Y : 1;
-      }
-    }         
-  }
 }

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/TrayInfo.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/TrayInfo.cs
@@ -49,8 +49,8 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// Recalculates OS coordinates in order to support WPFs coordinate
         /// system if OS scaling (DPIs) is not 100%.
         /// </summary>
-        /// <param name="point"></param>
-        /// <returns></returns>
+        /// <param name="point">Point</param>
+        /// <returns>Point</returns>
         public static Point GetDeviceCoordinates(Point point)
         {
           return new Point

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/TrayInfo.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/TrayInfo.cs
@@ -53,7 +53,11 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// <returns></returns>
         public static Point GetDeviceCoordinates(Point point)
         {
-          return new Point() { X = (int)(point.X / SystemInfo.DpiXFactor), Y = (int)(point.Y / SystemInfo.DpiYFactor) };
+          return new Point
+          {
+              X = (int)(point.X / SystemInfo.DpiFactorX),
+              Y = (int)(point.Y / SystemInfo.DpiFactorY)
+          };
         }
     }
 }

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/TrayInfo.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/TrayInfo.cs
@@ -1,8 +1,6 @@
 ﻿// Some interop code taken from Mike Marshall's AnyForm
 
-using System;
 using System.Drawing;
-using System.Runtime.InteropServices;
 
 namespace Hardcodet.Wpf.TaskbarNotification.Interop
 {
@@ -56,107 +54,6 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         public static Point GetDeviceCoordinates(Point point)
         {
           return new Point() { X = (int)(point.X / SystemInfo.DpiXFactor), Y = (int)(point.Y / SystemInfo.DpiYFactor) };
-        }
-    }
-
-
-    public class AppBarInfo
-    {
-        [DllImport("user32.dll")]
-        private static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
-
-        [DllImport("shell32.dll")]
-        private static extern uint SHAppBarMessage(uint dwMessage, ref APPBARDATA data);
-
-        [DllImport("user32.dll")]
-        private static extern int SystemParametersInfo(uint uiAction, uint uiParam,
-            IntPtr pvParam, uint fWinIni);
-
-
-        private const int ABE_BOTTOM = 3;
-        private const int ABE_LEFT = 0;
-        private const int ABE_RIGHT = 2;
-        private const int ABE_TOP = 1;
-
-        private const int ABM_GETTASKBARPOS = 0x00000005;
-
-        // SystemParametersInfo constants
-        private const uint SPI_GETWORKAREA = 0x0030;
-
-        private APPBARDATA m_data;
-
-        public ScreenEdge Edge
-        {
-            get { return (ScreenEdge) m_data.uEdge; }
-        }
-
-        public Rectangle WorkArea
-        {
-          get { return GetRectangle(m_data.rc); }
-        }
-
-        private Rectangle GetRectangle(RECT rc)
-        {
-            return new Rectangle(rc.left, rc.top, rc.right - rc.left, rc.bottom - rc.top);
-        }     
-
-        public void GetPosition(string strClassName, string strWindowName)
-        {
-            m_data = new APPBARDATA();
-            m_data.cbSize = (uint) Marshal.SizeOf(m_data.GetType());
-
-            IntPtr hWnd = FindWindow(strClassName, strWindowName);
-
-            if (hWnd != IntPtr.Zero)
-            {
-                uint uResult = SHAppBarMessage(ABM_GETTASKBARPOS, ref m_data);
-
-                if (uResult != 1)
-                {
-                    throw new Exception("Failed to communicate with the given AppBar");
-                }
-            }
-            else
-            {
-                throw new Exception("Failed to find an AppBar that matched the given criteria");
-            }
-        }
-
-
-        public void GetSystemTaskBarPosition()
-        {
-            GetPosition("Shell_TrayWnd", null);
-        }
-
-
-        public enum ScreenEdge
-        {
-            Undefined = -1,
-            Left = ABE_LEFT,
-            Top = ABE_TOP,
-            Right = ABE_RIGHT,
-            Bottom = ABE_BOTTOM
-        }
-
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct APPBARDATA
-        {
-            public uint cbSize;
-            public IntPtr hWnd;
-            public uint uCallbackMessage;
-            public uint uEdge;
-            public RECT rc;
-            public int lParam;
-        }
-
-        [StructLayout(LayoutKind.Sequential)]
-        private struct RECT
-        {
-            public int left;
-            public int top;
-            public int right;
-            public int bottom;
         }
     }
 }

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WinApi.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WinApi.cs
@@ -8,6 +8,8 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
     /// </summary>
     internal static class WinApi
     {
+        private const string User32 = "user32.dll";
+
         /// <summary>
         /// Creates, updates or deletes the taskbar icon.
         /// </summary>
@@ -18,7 +20,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// <summary>
         /// Creates the helper window that receives messages from the taskar icon.
         /// </summary>
-        [DllImport("USER32.DLL", EntryPoint = "CreateWindowExW", SetLastError = true)]
+        [DllImport(User32, EntryPoint = "CreateWindowExW", SetLastError = true)]
         public static extern IntPtr CreateWindowEx(int dwExStyle, [MarshalAs(UnmanagedType.LPWStr)] string lpClassName,
             [MarshalAs(UnmanagedType.LPWStr)] string lpWindowName, int dwStyle, int x, int y,
             int nWidth, int nHeight, IntPtr hWndParent, IntPtr hMenu, IntPtr hInstance,
@@ -28,13 +30,13 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// <summary>
         /// Processes a default windows procedure.
         /// </summary>
-        [DllImport("USER32.DLL")]
+        [DllImport(User32)]
         public static extern IntPtr DefWindowProc(IntPtr hWnd, uint msg, IntPtr wparam, IntPtr lparam);
 
         /// <summary>
         /// Registers the helper window class.
         /// </summary>
-        [DllImport("USER32.DLL", EntryPoint = "RegisterClassW", SetLastError = true)]
+        [DllImport(User32, EntryPoint = "RegisterClassW", SetLastError = true)]
         public static extern short RegisterClass(ref WindowClass lpWndClass);
 
         /// <summary>
@@ -42,7 +44,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// </summary>
         /// <param name="lpString"></param>
         /// <returns></returns>
-        [DllImport("User32.Dll", EntryPoint = "RegisterWindowMessageW")]
+        [DllImport(User32, EntryPoint = "RegisterWindowMessageW")]
         public static extern uint RegisterWindowMessage([MarshalAs(UnmanagedType.LPWStr)] string lpString);
 
         /// <summary>
@@ -51,7 +53,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// </summary>
         /// <param name="hWnd"></param>
         /// <returns></returns>
-        [DllImport("USER32.DLL", SetLastError = true)]
+        [DllImport(User32, SetLastError = true)]
         public static extern bool DestroyWindow(IntPtr hWnd);
 
 
@@ -60,7 +62,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// </summary>
         /// <param name="hWnd"></param>
         /// <returns></returns>
-        [DllImport("USER32.DLL")]
+        [DllImport(User32)]
         public static extern bool SetForegroundWindow(IntPtr hWnd);
 
 
@@ -72,18 +74,18 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// <returns>The maximum amount of time, in milliseconds, that can
         /// elapse between a first click and a second click for the OS to
         /// consider the mouse action a double-click.</returns>
-        [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
+        [DllImport(User32, CharSet = CharSet.Auto, ExactSpelling = true)]
         public static extern int GetDoubleClickTime();
 
 
         /// <summary>
         /// Gets the screen coordinates of the current mouse position.
         /// </summary>
-        [DllImport("USER32.DLL", SetLastError = true)]
+        [DllImport(User32, SetLastError = true)]
         public static extern bool GetPhysicalCursorPos(ref Point lpPoint);
 
 
-        [DllImport("USER32.DLL", SetLastError = true)]
+        [DllImport(User32, SetLastError = true)]
         public static extern bool GetCursorPos(ref Point lpPoint);
     }
 }

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WinApi.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WinApi.cs
@@ -43,7 +43,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// Registers a listener for a window message.
         /// </summary>
         /// <param name="lpString"></param>
-        /// <returns></returns>
+        /// <returns>uint</returns>
         [DllImport(User32, EntryPoint = "RegisterWindowMessageW")]
         public static extern uint RegisterWindowMessage([MarshalAs(UnmanagedType.LPWStr)] string lpString);
 
@@ -52,7 +52,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// taskbar icon.
         /// </summary>
         /// <param name="hWnd"></param>
-        /// <returns></returns>
+        /// <returns>bool</returns>
         [DllImport(User32, SetLastError = true)]
         public static extern bool DestroyWindow(IntPtr hWnd);
 
@@ -61,7 +61,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// Gives focus to a given window.
         /// </summary>
         /// <param name="hWnd"></param>
-        /// <returns></returns>
+        /// <returns>bool</returns>
         [DllImport(User32)]
         public static extern bool SetForegroundWindow(IntPtr hWnd);
 

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowClass.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowClass.cs
@@ -7,7 +7,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
     /// Callback delegate which is used by the Windows API to
     /// submit window messages.
     /// </summary>
-    public delegate IntPtr WindowProcedureHandler(IntPtr hwnd, uint uMsg, IntPtr wparam, IntPtr lparam);
+    public delegate IntPtr WindowProcedureHandler(IntPtr hWnd, uint uMsg, IntPtr wParam, IntPtr lParam);
 
 
     /// <summary>

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
@@ -131,7 +131,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// pointer rather than a real window handler.<br/>
         /// Used at design time.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>WindowMessageSink</returns>
         internal static WindowMessageSink CreateEmpty()
         {
             return new WindowMessageSink

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
@@ -169,7 +169,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
             wc.hIcon = IntPtr.Zero;
             wc.hCursor = IntPtr.Zero;
             wc.hbrBackground = IntPtr.Zero;
-            wc.lpszMenuName = "";
+            wc.lpszMenuName = string.Empty;
             wc.lpszClassName = WindowId;
 
             // Register the window class
@@ -200,20 +200,20 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// <summary>
         /// Callback method that receives messages from the taskbar area.
         /// </summary>
-        private IntPtr OnWindowMessageReceived(IntPtr hwnd, uint messageId, IntPtr wparam, IntPtr lparam)
+        private IntPtr OnWindowMessageReceived(IntPtr hWnd, uint messageId, IntPtr wparam, IntPtr lparam)
         {
             if (messageId == taskbarRestartMessageId)
             {
                 //recreate the icon if the taskbar was restarted (e.g. due to Win Explorer shutdown)
                 var listener = TaskbarCreated;
-                if(listener != null) listener();
+                listener?.Invoke();
             }
 
             //forward message
             ProcessWindowMessage(messageId, wparam, lparam);
 
             // Pass the message to the default window procedure
-            return WinApi.DefWindowProc(hwnd, messageId, wparam, lparam);
+            return WinApi.DefWindowProc(hWnd, messageId, wparam, lparam);
         }
 
 
@@ -278,13 +278,13 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
 
                 case 0x402:
                     var listener = BalloonToolTipChanged;
-                    if (listener != null) listener(true);
+                    listener?.Invoke(true);
                     break;
 
                 case 0x403:
                 case 0x404:
                     listener = BalloonToolTipChanged;
-                    if (listener != null) listener(false);
+                    listener?.Invoke(false);
                     break;
 
                 case 0x405:
@@ -293,12 +293,12 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
 
                 case 0x406:
                     listener = ChangeToolTipStateRequest;
-                    if (listener != null) listener(true);
+                    listener?.Invoke(true);
                     break;
 
                 case 0x407:
                     listener = ChangeToolTipStateRequest;
-                    if (listener != null) listener(false);
+                    listener?.Invoke(false);
                     break;
 
                 default:
@@ -328,7 +328,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
             Dispose(true);
 
             // This object will be cleaned up by the Dispose method.
-            // Therefore, you should call GC.SupressFinalize to
+            // Therefore, you should call GC.SuppressFinalize to
             // take this object off the finalization queue 
             // and prevent finalization code for this object
             // from executing a second time.
@@ -340,7 +340,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// method does not get called. This gives this base class the
         /// opportunity to finalize.
         /// <para>
-        /// Important: Do not provide destructors in types derived from
+        /// Important: Do not provide destructor in types derived from
         /// this class.
         /// </para>
         /// </summary>

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
@@ -185,11 +185,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
 
             if (MessageWindowHandle == IntPtr.Zero)
             {
-#if SILVERLIGHT
-      	throw new Exception("Message window handle was not a valid pointer.");
-#else
                 throw new Win32Exception("Message window handle was not a valid pointer");
-#endif
             }
         }
 
@@ -200,7 +196,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         /// <summary>
         /// Callback method that receives messages from the taskbar area.
         /// </summary>
-        private IntPtr OnWindowMessageReceived(IntPtr hWnd, uint messageId, IntPtr wparam, IntPtr lparam)
+        private IntPtr OnWindowMessageReceived(IntPtr hWnd, uint messageId, IntPtr wParam, IntPtr lParam)
         {
             if (messageId == taskbarRestartMessageId)
             {
@@ -210,10 +206,10 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
             }
 
             //forward message
-            ProcessWindowMessage(messageId, wparam, lparam);
+            ProcessWindowMessage(messageId, wParam, lParam);
 
             // Pass the message to the default window procedure
-            return WinApi.DefWindowProc(hWnd, messageId, wparam, lparam);
+            return WinApi.DefWindowProc(hWnd, messageId, wParam, lParam);
         }
 
 

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Properties/AssemblyInfo.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Reflection;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using System.Windows;
 using System.Windows.Markup;
 

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/RoutedEventHelper.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/RoutedEventHelper.cs
@@ -18,13 +18,13 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// <param name="args">RoutedEventArgs to use when raising the event</param>
         internal static void RaiseEvent(DependencyObject target, RoutedEventArgs args)
         {
-            if (target is UIElement)
+            if (target is UIElement uiElement)
             {
-                (target as UIElement).RaiseEvent(args);
+                uiElement.RaiseEvent(args);
             }
-            else if (target is ContentElement)
+            else if (target is ContentElement contentElement)
             {
-                (target as ContentElement).RaiseEvent(args);
+                contentElement.RaiseEvent(args);
             }
         }
 
@@ -37,18 +37,13 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// <param name="handler">Event handler to be added</param>
         internal static void AddHandler(DependencyObject element, RoutedEvent routedEvent, Delegate handler)
         {
-            UIElement uie = element as UIElement;
-            if (uie != null)
+            if (element is UIElement uie)
             {
                 uie.AddHandler(routedEvent, handler);
             }
-            else
+            else if (element is ContentElement ce)
             {
-                ContentElement ce = element as ContentElement;
-                if (ce != null)
-                {
-                    ce.AddHandler(routedEvent, handler);
-                }
+                ce.AddHandler(routedEvent, handler);
             }
         }
 
@@ -61,18 +56,13 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// <param name="handler">Event handler to be removed</param>
         internal static void RemoveHandler(DependencyObject element, RoutedEvent routedEvent, Delegate handler)
         {
-            UIElement uie = element as UIElement;
-            if (uie != null)
+            if (element is UIElement uie)
             {
                 uie.RemoveHandler(routedEvent, handler);
             }
-            else
+            else if (element is ContentElement ce)
             {
-                ContentElement ce = element as ContentElement;
-                if (ce != null)
-                {
-                    ce.RemoveHandler(routedEvent, handler);
-                }
+                ce.RemoveHandler(routedEvent, handler);
             }
         }
 

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/TaskbarIcon.Declarations.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/TaskbarIcon.Declarations.cs
@@ -54,7 +54,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// TrayPopupResolved Read-Only Dependency Property
         /// </summary>
         private static readonly DependencyPropertyKey TrayPopupResolvedPropertyKey
-            = DependencyProperty.RegisterReadOnly("TrayPopupResolved", typeof (Popup), typeof (TaskbarIcon),
+            = DependencyProperty.RegisterReadOnly(nameof(TrayPopupResolved), typeof (Popup), typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null));
 
 
@@ -96,7 +96,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// TrayToolTipResolved Read-Only Dependency Property
         /// </summary>
         private static readonly DependencyPropertyKey TrayToolTipResolvedPropertyKey
-            = DependencyProperty.RegisterReadOnly("TrayToolTipResolved", typeof (ToolTip), typeof (TaskbarIcon),
+            = DependencyProperty.RegisterReadOnly(nameof(TrayToolTipResolved), typeof (ToolTip), typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null));
 
 
@@ -139,7 +139,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// CustomBalloon Read-Only Dependency Property
         /// </summary>
         private static readonly DependencyPropertyKey CustomBalloonPropertyKey
-            = DependencyProperty.RegisterReadOnly("CustomBalloon", typeof (Popup), typeof (TaskbarIcon),
+            = DependencyProperty.RegisterReadOnly(nameof(CustomBalloon), typeof (Popup), typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null));
 
         /// <summary>
@@ -198,7 +198,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// Resolves an image source and updates the <see cref="Icon" /> property accordingly.
         /// </summary>
         public static readonly DependencyProperty IconSourceProperty =
-            DependencyProperty.Register("IconSource",
+            DependencyProperty.Register(nameof(IconSource),
                 typeof (ImageSource),
                 typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null, IconSourcePropertyChanged));
@@ -256,10 +256,10 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// was set or if custom tooltips are not supported.
         /// </summary>
         public static readonly DependencyProperty ToolTipTextProperty =
-            DependencyProperty.Register("ToolTipText",
+            DependencyProperty.Register(nameof(ToolTipText),
                 typeof (string),
                 typeof (TaskbarIcon),
-                new FrameworkPropertyMetadata(String.Empty, ToolTipTextPropertyChanged));
+                new FrameworkPropertyMetadata(string.Empty, ToolTipTextPropertyChanged));
 
 
         /// <summary>
@@ -330,7 +330,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// the <see cref="ToolTipText"/> property is set as well.
         /// </summary>
         public static readonly DependencyProperty TrayToolTipProperty =
-            DependencyProperty.Register("TrayToolTip",
+            DependencyProperty.Register(nameof(TrayToolTip),
                 typeof (UIElement),
                 typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null, TrayToolTipPropertyChanged));
@@ -404,7 +404,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// A control that is displayed as a popup when the taskbar icon is clicked.
         /// </summary>
         public static readonly DependencyProperty TrayPopupProperty =
-            DependencyProperty.Register("TrayPopup",
+            DependencyProperty.Register(nameof(TrayPopup),
                 typeof (UIElement),
                 typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null, TrayPopupPropertyChanged));
@@ -473,7 +473,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// Defaults to <see cref="PopupActivationMode.RightClick"/>.
         /// </summary>
         public static readonly DependencyProperty MenuActivationProperty =
-            DependencyProperty.Register("MenuActivation",
+            DependencyProperty.Register(nameof(MenuActivation),
                 typeof (PopupActivationMode),
                 typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(PopupActivationMode.RightClick));
@@ -501,7 +501,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// Default is <see cref="PopupActivationMode.LeftClick" />.
         /// </summary>
         public static readonly DependencyProperty PopupActivationProperty =
-            DependencyProperty.Register("PopupActivation",
+            DependencyProperty.Register(nameof(PopupActivation),
                 typeof (PopupActivationMode),
                 typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(PopupActivationMode.LeftClick));
@@ -673,7 +673,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// double clicked.
         /// </summary>
         public static readonly DependencyProperty DoubleClickCommandProperty =
-            DependencyProperty.Register("DoubleClickCommand",
+            DependencyProperty.Register(nameof(DoubleClickCommand),
                 typeof (ICommand),
                 typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null));
@@ -700,7 +700,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// Command parameter for the <see cref="DoubleClickCommand"/>.
         /// </summary>
         public static readonly DependencyProperty DoubleClickCommandParameterProperty =
-            DependencyProperty.Register("DoubleClickCommandParameter",
+            DependencyProperty.Register(nameof(DoubleClickCommandParameter),
                 typeof (object),
                 typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null));
@@ -726,7 +726,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// The target of the command that is fired if the notify icon is double clicked.
         /// </summary>
         public static readonly DependencyProperty DoubleClickCommandTargetProperty =
-            DependencyProperty.Register("DoubleClickCommandTarget",
+            DependencyProperty.Register(nameof(DoubleClickCommandTarget),
                 typeof (IInputElement),
                 typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null));
@@ -753,7 +753,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// double clicked.
         /// </summary>
         public static readonly DependencyProperty LeftClickCommandProperty =
-            DependencyProperty.Register("LeftClickCommand",
+            DependencyProperty.Register(nameof(LeftClickCommand),
                 typeof (ICommand),
                 typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null));
@@ -780,7 +780,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// Command parameter for the <see cref="LeftClickCommand"/>.
         /// </summary>
         public static readonly DependencyProperty LeftClickCommandParameterProperty =
-            DependencyProperty.Register("LeftClickCommandParameter",
+            DependencyProperty.Register(nameof(LeftClickCommandParameter),
                 typeof (object),
                 typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null));
@@ -807,7 +807,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// The target of the command that is fired if the notify icon is clicked.
         /// </summary>
         public static readonly DependencyProperty LeftClickCommandTargetProperty =
-            DependencyProperty.Register("LeftClickCommandTarget",
+            DependencyProperty.Register(nameof(LeftClickCommandTarget),
                 typeof (IInputElement),
                 typeof (TaskbarIcon),
                 new FrameworkPropertyMetadata(null));
@@ -834,7 +834,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// Set to true to make left clicks work without delay.
         /// </summary>
         public static readonly DependencyProperty NoLeftClickDelayProperty =
-            DependencyProperty.Register("NoLeftClickDelay",
+            DependencyProperty.Register(nameof(NoLeftClickDelay),
                 typeof(bool),
                 typeof(TaskbarIcon),
                 new FrameworkPropertyMetadata(false));
@@ -893,8 +893,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayLeftMouseDownEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayLeftMouseDownEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -935,8 +934,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayRightMouseDownEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayRightMouseDownEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -977,8 +975,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayMiddleMouseDownEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayMiddleMouseDownEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1018,8 +1015,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayLeftMouseUpEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayLeftMouseUpEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1059,8 +1055,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayRightMouseUpEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayRightMouseUpEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1101,8 +1096,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayMiddleMouseUpEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayMiddleMouseUpEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1145,8 +1139,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayMouseDoubleClickEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayMouseDoubleClickEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1186,8 +1179,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            var args = new RoutedEventArgs();
-            args.RoutedEvent = TrayMouseMoveEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayMouseMoveEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1228,8 +1220,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayBalloonTipShownEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayBalloonTipShownEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1270,8 +1261,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayBalloonTipClosedEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayBalloonTipClosedEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1312,8 +1302,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayBalloonTipClickedEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayBalloonTipClickedEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1354,8 +1343,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayContextMenuOpenEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayContextMenuOpenEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1392,8 +1380,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = PreviewTrayContextMenuOpenEvent;
+            RoutedEventArgs args = new RoutedEventArgs(PreviewTrayContextMenuOpenEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1433,8 +1420,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayPopupOpenEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayPopupOpenEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1471,8 +1457,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = PreviewTrayPopupOpenEvent;
+            RoutedEventArgs args = new RoutedEventArgs(PreviewTrayPopupOpenEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1512,8 +1497,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayToolTipOpenEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayToolTipOpenEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1550,8 +1534,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = PreviewTrayToolTipOpenEvent;
+            RoutedEventArgs args = new RoutedEventArgs(PreviewTrayToolTipOpenEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1591,8 +1574,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = TrayToolTipCloseEvent;
+            RoutedEventArgs args = new RoutedEventArgs(TrayToolTipCloseEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1629,8 +1611,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = PreviewTrayToolTipCloseEvent;
+            RoutedEventArgs args = new RoutedEventArgs(PreviewTrayToolTipCloseEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1675,8 +1656,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = PopupOpenedEvent;
+            RoutedEventArgs args = new RoutedEventArgs(PopupOpenedEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1719,8 +1699,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = ToolTipOpenedEvent;
+            RoutedEventArgs args = new RoutedEventArgs(ToolTipOpenedEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1763,8 +1742,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (target == null) return null;
 
-            RoutedEventArgs args = new RoutedEventArgs();
-            args.RoutedEvent = ToolTipCloseEvent;
+            RoutedEventArgs args = new RoutedEventArgs(ToolTipCloseEvent);
             RoutedEventHelper.RaiseEvent(target, args);
             return args;
         }
@@ -1864,7 +1842,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         #region ParentTaskbarIcon
 
         /// <summary>
-        /// An attached property that is assigned to displayed UI elements (balloos, tooltips, context menus), and
+        /// An attached property that is assigned to displayed UI elements (balloons, tooltips, context menus), and
         /// that can be used to bind to this control. The attached property is being derived, so binding is
         /// quite straightforward:
         /// <code>
@@ -1907,11 +1885,11 @@ namespace Hardcodet.Wpf.TaskbarNotification
             VisibilityProperty.OverrideMetadata(typeof (TaskbarIcon), md);
 
             //register change listener for the DataContext property
-            md = new FrameworkPropertyMetadata(new PropertyChangedCallback(DataContextPropertyChanged));
+            md = new FrameworkPropertyMetadata(DataContextPropertyChanged);
             DataContextProperty.OverrideMetadata(typeof (TaskbarIcon), md);
 
             //register change listener for the ContextMenu property
-            md = new FrameworkPropertyMetadata(new PropertyChangedCallback(ContextMenuPropertyChanged));
+            md = new FrameworkPropertyMetadata(ContextMenuPropertyChanged);
             ContextMenuProperty.OverrideMetadata(typeof (TaskbarIcon), md);
         }
     }

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/TaskbarIcon.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/TaskbarIcon.cs
@@ -72,10 +72,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// <summary>
         /// The time we should wait for a double click.
         /// </summary>
-        private int DoubleClickWaitTime
-        {
-            get { return NoLeftClickDelay ? 0 : WinApi.GetDoubleClickTime(); }
-        }
+        private int DoubleClickWaitTime => NoLeftClickDelay ? 0 : WinApi.GetDoubleClickTime();
 
         /// <summary>
         /// A timer that is used to close open balloon tooltips.
@@ -92,10 +89,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// on the OS. Windows Vista or higher is required in order to
         /// support this feature.
         /// </summary>
-        public bool SupportsCustomToolTips
-        {
-            get { return messageSink.Version == NotifyIconVersion.Vista; }
-        }
+        public bool SupportsCustomToolTips => messageSink.Version == NotifyIconVersion.Vista;
 
 
         /// <summary>
@@ -156,10 +150,20 @@ namespace Hardcodet.Wpf.TaskbarNotification
         #endregion
 
         #region Custom Balloons
+        /// <summary>
+        /// A delegate to handle customer popup positions.
+        /// </summary>
         public delegate Point GetCustomPopupPosition();
 
-        public GetCustomPopupPosition CustomPopupPosition;
+        /// <summary>
+        /// Specify a custom popup position
+        /// </summary>
+        public GetCustomPopupPosition CustomPopupPosition { get; set; }
 
+        /// <summary>
+        /// Returns the location of the system tray
+        /// </summary>
+        /// <returns>Point</returns>
         public Point GetPopupTrayPosition()
         {
             return TrayInfo.GetTrayLocation();
@@ -171,13 +175,13 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// <param name="balloon"></param>
         /// <param name="animation">An optional animation for the popup.</param>
         /// <param name="timeout">The time after which the popup is being closed.
-        /// Submit null in order to keep the balloon open inde
+        /// Submit null in order to keep the balloon open indefinitely
         /// </param>
         /// <exception cref="ArgumentNullException">If <paramref name="balloon"/>
         /// is a null reference.</exception>
         public void ShowCustomBalloon(UIElement balloon, PopupAnimation animation, int? timeout)
         {
-            Dispatcher dispatcher = this.GetDispatcher();
+            var dispatcher = this.GetDispatcher();
             if (!dispatcher.CheckAccess())
             {
                 var action = new Action(() => ShowCustomBalloon(balloon, animation, timeout));
@@ -185,7 +189,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
                 return;
             }
 
-            if (balloon == null) throw new ArgumentNullException("balloon");
+            if (balloon == null) throw new ArgumentNullException(nameof(balloon));
             if (timeout.HasValue && timeout < 500)
             {
                 string msg = "Invalid timeout of {0} milliseconds. Timeout must be at least 500 ms";
@@ -819,6 +823,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
 
                 if (largeIcon)
                 {
+                    // ReSharper disable once BitwiseOperatorOnEnumWithoutFlags
                     flags |= BalloonFlags.LargeIcon;
                 }
 

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Util.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Util.cs
@@ -277,7 +277,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// <summary>
         /// Returns a dispatcher for multi-threaded scenarios
         /// </summary>
-        /// <returns></returns>
+        /// <returns>Dispatcher</returns>
         internal static Dispatcher GetDispatcher(this DispatcherObject source)
         {
             //use the application's dispatcher by default
@@ -286,7 +286,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
             //fallback for WinForms environments
             if (source.Dispatcher != null) return source.Dispatcher;
 
-            //ultimatively use the thread's dispatcher
+            // ultimately use the thread's dispatcher
             return Dispatcher.CurrentDispatcher;
         }
 

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Util.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Util.cs
@@ -175,7 +175,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
             if (streamInfo == null)
             {
                 string msg = "The supplied image source '{0}' could not be resolved.";
-                msg = String.Format(msg, imageSource);
+                msg = string.Format(msg, imageSource);
                 throw new ArgumentException(msg);
             }
 

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/App.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/App.xaml.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
-using System.Data;
-using System.Linq;
-using System.Windows;
-using Hardcodet.Wpf.TaskbarNotification;
+﻿using System.Windows;
 
 namespace Samples
 {

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Commands/CommandBase.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Commands/CommandBase.cs
@@ -62,7 +62,7 @@ namespace Samples.Commands
         /// </param>
         public virtual bool CanExecute(object parameter)
         {
-            return IsDesignMode ? false : true;
+            return !IsDesignMode;
         }
 
 
@@ -87,7 +87,7 @@ namespace Samples.Commands
         {
             if (IsDesignMode) return null;
 
-            //get the showcase window off the taskbaricon
+            // get the showcase window off the taskbar icon
             var tb = commandParameter as TaskbarIcon;
             return tb == null ? null : TryFindParent<Window>(tb);
         }
@@ -97,14 +97,13 @@ namespace Samples.Commands
         /// <summary>
         /// Finds a parent of a given item on the visual tree.
         /// </summary>
-        /// <typeparam name="T">The type of the queried item.</typeparam>
+        /// <typeparam name="TParent">The type of the queried item.</typeparam>
         /// <param name="child">A direct or indirect child of the
         /// queried item.</param>
         /// <returns>The first parent item that matches the submitted
         /// type parameter. If not matching item can be found, a null
         /// reference is being returned.</returns>
-        public static T TryFindParent<T>(DependencyObject child)
-            where T : DependencyObject
+        public static TParent TryFindParent<TParent>(DependencyObject child) where TParent : DependencyObject
         {
             //get parent item
             DependencyObject parentObject = GetParentObject(child);
@@ -113,16 +112,13 @@ namespace Samples.Commands
             if (parentObject == null) return null;
 
             //check if the parent matches the type we're looking for
-            T parent = parentObject as T;
-            if (parent != null)
+            if (parentObject is TParent parent)
             {
                 return parent;
             }
-            else
-            {
-                //use recursion to proceed with next level
-                return TryFindParent<T>(parentObject);
-            }
+
+            //use recursion to proceed with next level
+            return TryFindParent<TParent>(parentObject);
         }
 
         /// <summary>
@@ -137,15 +133,14 @@ namespace Samples.Commands
         public static DependencyObject GetParentObject(DependencyObject child)
         {
             if (child == null) return null;
-            ContentElement contentElement = child as ContentElement;
 
-            if (contentElement != null)
+            if (child is ContentElement contentElement)
             {
                 DependencyObject parent = ContentOperations.GetParent(contentElement);
                 if (parent != null) return parent;
 
                 FrameworkContentElement fce = contentElement as FrameworkContentElement;
-                return fce != null ? fce.Parent : null;
+                return fce?.Parent;
             }
 
             //if it's not a ContentElement, rely on VisualTreeHelper

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Commands/CommandBase.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Commands/CommandBase.cs
@@ -82,7 +82,7 @@ namespace Samples.Commands
         /// Resolves the window that owns the TaskbarIcon class.
         /// </summary>
         /// <param name="commandParameter"></param>
-        /// <returns></returns>
+        /// <returns>Window</returns>
         protected Window GetTaskbarWindow(object commandParameter)
         {
             if (IsDesignMode) return null;

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Main.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Main.xaml.cs
@@ -82,17 +82,19 @@ namespace Samples
             ShowDialog(new DataBoundToolTipWindow());
         }
 		
-		private void btnMvvm_Click(object sender, System.Windows.RoutedEventArgs e)
+		private void btnMvvm_Click(object sender, RoutedEventArgs e)
 		{
 			ShowDialog(new MvvmSampleWindow());
 		}
 
         private void btnMainSample_Click(object sender, RoutedEventArgs e)
         {
-            var sampleWindow = new ShowcaseWindow();
+            var sampleWindow = new ShowcaseWindow
+            {
+                Owner = this,
+                WindowStartupLocation = WindowStartupLocation.CenterScreen
+            };
 
-            sampleWindow.Owner = this;
-            sampleWindow.WindowStartupLocation = WindowStartupLocation.CenterScreen;
             sampleWindow.ShowDialog();
         }
 

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Properties/AssemblyInfo.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-﻿using System.Reflection;
-using System.Resources;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using System.Windows;
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Showcase/FancyBalloon.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Showcase/FancyBalloon.xaml.cs
@@ -1,18 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
-using System.Windows.Data;
-using System.Windows.Documents;
 using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Animation;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 using Hardcodet.Wpf.TaskbarNotification;
 
 namespace Samples
@@ -30,10 +20,10 @@ namespace Samples
         /// Description
         /// </summary>
         public static readonly DependencyProperty BalloonTextProperty =
-            DependencyProperty.Register("BalloonText",
+            DependencyProperty.Register(nameof(BalloonText),
                 typeof (string),
                 typeof (FancyBalloon),
-                new FrameworkPropertyMetadata(""));
+                new FrameworkPropertyMetadata(string.Empty));
 
         /// <summary>
         /// A property wrapper for the <see cref="BalloonTextProperty"/>

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Showcase/FancyPopup.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Showcase/FancyPopup.xaml.cs
@@ -14,7 +14,7 @@ namespace Samples
         /// The number of clicks on the popup button.
         /// </summary>
         public static readonly DependencyProperty ClickCountProperty =
-            DependencyProperty.Register("ClickCount",
+            DependencyProperty.Register(nameof(ClickCount),
                 typeof (int),
                 typeof (FancyPopup),
                 new FrameworkPropertyMetadata(0));

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Showcase/FancyToolTip.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Showcase/FancyToolTip.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
-using Hardcodet.Wpf.TaskbarNotification;
+﻿using System.Windows;
 
 namespace Samples
 {
@@ -25,10 +13,10 @@ namespace Samples
         /// The tooltip details.
         /// </summary>
         public static readonly DependencyProperty InfoTextProperty =
-            DependencyProperty.Register("InfoText",
+            DependencyProperty.Register(nameof(InfoText),
                 typeof (string),
                 typeof (FancyToolTip),
-                new FrameworkPropertyMetadata(""));
+                new FrameworkPropertyMetadata(string.Empty));
 
         /// <summary>
         /// A property wrapper for the <see cref="InfoTextProperty"/>
@@ -45,7 +33,7 @@ namespace Samples
 
         public FancyToolTip()
         {
-            this.InitializeComponent();
+            InitializeComponent();
         }
     }
 }

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Showcase/WelcomeBalloon.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Showcase/WelcomeBalloon.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace Samples
 {

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/02 - ToolTips/InlineToolTipWindow.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/02 - ToolTips/InlineToolTipWindow.xaml.cs
@@ -1,15 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace Samples.Tutorials.ToolTips
 {

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/02 - ToolTips/SimpleUserControl.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/02 - ToolTips/SimpleUserControl.xaml.cs
@@ -1,16 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows.Controls;
 
 namespace Samples.Tutorials.ToolTips
 {

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/02 - ToolTips/UserControlToolTipWindow.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/02 - ToolTips/UserControlToolTipWindow.xaml.cs
@@ -1,15 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace Samples.Tutorials.ToolTips
 {

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/03 - Popups/InlinePopupWindow.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/03 - Popups/InlinePopupWindow.xaml.cs
@@ -1,15 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace Samples.Tutorials.Popups
 {

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/04 - ContextMenus/InlineContextMenuWindow.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/04 - ContextMenus/InlineContextMenuWindow.xaml.cs
@@ -1,7 +1,4 @@
-﻿using System.Diagnostics;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Input;
+﻿using System.Windows;
 
 namespace Samples.Tutorials.ContextMenus
 {
@@ -24,12 +21,12 @@ namespace Samples.Tutorials.ContextMenus
             base.OnClosing(e);
         }
 
-        private void MyNotifyIcon_TrayContextMenuOpen(object sender, System.Windows.RoutedEventArgs e)
+        private void MyNotifyIcon_TrayContextMenuOpen(object sender, RoutedEventArgs e)
         {
             OpenEventCounter.Text = (int.Parse(OpenEventCounter.Text) + 1).ToString();
         }
 
-        private void MyNotifyIcon_PreviewTrayContextMenuOpen(object sender, System.Windows.RoutedEventArgs e)
+        private void MyNotifyIcon_PreviewTrayContextMenuOpen(object sender, RoutedEventArgs e)
         {
             //marking the event as handled suppresses the context menu
             e.Handled = (bool) SuppressContextMenu.IsChecked;

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/05 - Balloons/BalloonSampleWindow.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/05 - Balloons/BalloonSampleWindow.xaml.cs
@@ -1,17 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
+﻿using System.Windows;
 using System.Windows.Controls.Primitives;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
-using Hardcodet.Wpf.TaskbarNotification;
 
 namespace Samples.Tutorials.Balloons
 {

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/06 - Commands/CommandWindow.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/06 - Commands/CommandWindow.xaml.cs
@@ -1,15 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace Samples.Tutorials.Commands
 {

--- a/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/09 - MVVM/ClockPopup.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Sample Project/Tutorials/09 - MVVM/ClockPopup.xaml.cs
@@ -9,7 +9,7 @@ namespace Samples.Tutorials.MvvmSample
 	{
 		public ClockPopup()
 		{
-			this.InitializeComponent();
+			InitializeComponent();
 		}
 	}
 }

--- a/Hardcodet.NotifyIcon.Wpf/Source/Windowless Sample/DelegateCommand.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Windowless Sample/DelegateCommand.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Windowless_Sample
+{
+    /// <summary>
+    /// Simplistic delegate command for the demo.
+    /// </summary>
+    public class DelegateCommand : ICommand
+    {
+        public Action CommandAction { get; set; }
+        public Func<bool> CanExecuteFunc { get; set; }
+
+        public void Execute(object parameter)
+        {
+            CommandAction();
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            return CanExecuteFunc == null  || CanExecuteFunc();
+        }
+
+        public event EventHandler CanExecuteChanged
+        {
+            add { CommandManager.RequerySuggested += value; }
+            remove { CommandManager.RequerySuggested -= value; }
+        }
+    }
+}

--- a/Hardcodet.NotifyIcon.Wpf/Source/Windowless Sample/MainWindow.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Windowless Sample/MainWindow.xaml.cs
@@ -1,17 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
+﻿using System.Windows;
 
 namespace Windowless_Sample
 {

--- a/Hardcodet.NotifyIcon.Wpf/Source/Windowless Sample/NotifyIconViewModel.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Windowless Sample/NotifyIconViewModel.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Windows;
+﻿using System.Windows;
 using System.Windows.Input;
 
 namespace Windowless_Sample
@@ -55,32 +54,6 @@ namespace Windowless_Sample
             {
                 return new DelegateCommand {CommandAction = () => Application.Current.Shutdown()};
             }
-        }
-    }
-
-
-    /// <summary>
-    /// Simplistic delegate command for the demo.
-    /// </summary>
-    public class DelegateCommand : ICommand
-    {
-        public Action CommandAction { get; set; }
-        public Func<bool> CanExecuteFunc { get; set; }
-
-        public void Execute(object parameter)
-        {
-            CommandAction();
-        }
-
-        public bool CanExecute(object parameter)
-        {
-            return CanExecuteFunc == null  || CanExecuteFunc();
-        }
-
-        public event EventHandler CanExecuteChanged
-        {
-            add { CommandManager.RequerySuggested += value; }
-            remove { CommandManager.RequerySuggested -= value; }
         }
     }
 }

--- a/Hardcodet.NotifyIcon.Wpf/Source/Windowless Sample/Properties/AssemblyInfo.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/Windowless Sample/Properties/AssemblyInfo.cs
@@ -1,7 +1,4 @@
-﻿using System.Reflection;
-using System.Resources;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 using System.Windows;
 
 // Setting ComVisible to false makes the types in this assembly not visible 

--- a/Hardcodet.NotifyIcon.Wpf/Source/WindowsFormsSample/FancyPopup.xaml.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/WindowsFormsSample/FancyPopup.xaml.cs
@@ -13,7 +13,7 @@ namespace Samples
         /// The number of clicks on the popup button.
         /// </summary>
         public static readonly DependencyProperty ClickCountProperty =
-            DependencyProperty.Register("ClickCount",
+            DependencyProperty.Register(nameof(ClickCount),
                 typeof (int),
                 typeof (FancyPopup),
                 new FrameworkPropertyMetadata(0));

--- a/Hardcodet.NotifyIcon.Wpf/Source/WindowsFormsSample/Program.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/WindowsFormsSample/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Windows.Forms;
-using Samples;
 
 namespace WindowsFormsSample
 {

--- a/Hardcodet.NotifyIcon.Wpf/Source/WindowsFormsSample/Properties/AssemblyInfo.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/WindowsFormsSample/Properties/AssemblyInfo.cs
@@ -1,6 +1,4 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+﻿using System.Runtime.InteropServices;
 
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 


### PR DESCRIPTION
These changes should improve the readability and stability of the code base, also when moving / modifying. Especially not using hard-coded strings.

As the project was already at C# 7.3, I modified some of the code to use more of the features, but only if these improve readability. I could have been a lot more aggressive, but assume that would be to much.

Removed the "this." references where possible, as it's unneeded from my standpoint.
Moved 2 classes in their own files, it's a common convention not to have multiple classes in one file.

In TaskbarIcon there was a lot of lock(this), which is bad practice (but most likely not an issue here), I replaced this with a lock on a separate object. This might increase the memory usage with a few bytes, but I would advice to do it anyway.

Also fixed some typos in documentation.

What is missing, are some code / naming conventions (like are private fields prefixed with an _ or not etc)

Just look if you like these changes