### PR TITLE
Removing some of the "magic numbers"

### DIFF
--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/NotifyIconVersion.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/NotifyIconVersion.cs
@@ -19,8 +19,8 @@
         Win2000 = 0x3,
 
         /// <summary>
-        /// Extended tooltip support, which is available
-        /// for Vista and later.
+        /// Extended tooltip support, which is available for Vista and later.
+        /// Detailed information about what the different versions do, can be found <a href="https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyicona">here</a>
         /// </summary>
         Vista = 0x4
     }

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
@@ -225,17 +225,17 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         {
             if (msg != CallbackMessageId) return;
 
-            switch (lParam.ToInt32())
+            switch ((WindowsMessages)lParam.ToInt32())
             {
-                case 0x200:
+                case WindowsMessages.WM_MOUSEMOVE:
                     MouseEventReceived(MouseEvent.MouseMove);
                     break;
 
-                case 0x201:
+                case WindowsMessages.WM_LBUTTONDOWN:
                     MouseEventReceived(MouseEvent.IconLeftMouseDown);
                     break;
 
-                case 0x202:
+                case WindowsMessages.WM_LBUTTONUP:
                     if (!isDoubleClick)
                     {
                         MouseEventReceived(MouseEvent.IconLeftMouseUp);
@@ -243,56 +243,56 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                     isDoubleClick = false;
                     break;
 
-                case 0x203:
+                case WindowsMessages.WM_LBUTTONDBLCLK:
                     isDoubleClick = true;
                     MouseEventReceived(MouseEvent.IconDoubleClick);
                     break;
 
-                case 0x204:
+                case WindowsMessages.WM_RBUTTONDOWN:
                     MouseEventReceived(MouseEvent.IconRightMouseDown);
                     break;
 
-                case 0x205:
+                case WindowsMessages.WM_RBUTTONUP:
                     MouseEventReceived(MouseEvent.IconRightMouseUp);
                     break;
 
-                case 0x206:
+                case WindowsMessages.WM_RBUTTONDBLCLK:
                     //double click with right mouse button - do not trigger event
                     break;
 
-                case 0x207:
+                case WindowsMessages.WM_MBUTTONDOWN:
                     MouseEventReceived(MouseEvent.IconMiddleMouseDown);
                     break;
 
-                case 520:
+                case WindowsMessages.WM_MBUTTONUP:
                     MouseEventReceived(MouseEvent.IconMiddleMouseUp);
                     break;
 
-                case 0x209:
+                case WindowsMessages.WM_MBUTTONDBLCLK:
                     //double click with middle mouse button - do not trigger event
                     break;
 
-                case 0x402:
+                case WindowsMessages.WM_USER2:
                     var listener = BalloonToolTipChanged;
                     listener?.Invoke(true);
                     break;
 
-                case 0x403:
-                case 0x404:
+                case WindowsMessages.WM_USER3:
+                case WindowsMessages.WM_USER4:
                     listener = BalloonToolTipChanged;
                     listener?.Invoke(false);
                     break;
 
-                case 0x405:
+                case WindowsMessages.WM_USER5:
                     MouseEventReceived(MouseEvent.BalloonToolTipClicked);
                     break;
 
-                case 0x406:
+                case WindowsMessages.WM_USER6:
                     listener = ChangeToolTipStateRequest;
                     listener?.Invoke(true);
                     break;
 
-                case 0x407:
+                case WindowsMessages.WM_USER7:
                     listener = ChangeToolTipStateRequest;
                     listener?.Invoke(false);
                     break;

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
@@ -235,32 +235,32 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                     break;
 
                 case WindowsMessages.WM_MOUSEMOVE:
-                    MouseEventReceived(MouseEvent.MouseMove);
+                    MouseEventReceived?.Invoke(MouseEvent.MouseMove);
                     break;
 
                 case WindowsMessages.WM_LBUTTONDOWN:
-                    MouseEventReceived(MouseEvent.IconLeftMouseDown);
+                    MouseEventReceived?.Invoke(MouseEvent.IconLeftMouseDown);
                     break;
 
                 case WindowsMessages.WM_LBUTTONUP:
                     if (!isDoubleClick)
                     {
-                        MouseEventReceived(MouseEvent.IconLeftMouseUp);
+                        MouseEventReceived?.Invoke(MouseEvent.IconLeftMouseUp);
                     }
                     isDoubleClick = false;
                     break;
 
                 case WindowsMessages.WM_LBUTTONDBLCLK:
                     isDoubleClick = true;
-                    MouseEventReceived(MouseEvent.IconDoubleClick);
+                    MouseEventReceived?.Invoke(MouseEvent.IconDoubleClick);
                     break;
 
                 case WindowsMessages.WM_RBUTTONDOWN:
-                    MouseEventReceived(MouseEvent.IconRightMouseDown);
+                    MouseEventReceived?.Invoke(MouseEvent.IconRightMouseDown);
                     break;
 
                 case WindowsMessages.WM_RBUTTONUP:
-                    MouseEventReceived(MouseEvent.IconRightMouseUp);
+                    MouseEventReceived?.Invoke(MouseEvent.IconRightMouseUp);
                     break;
 
                 case WindowsMessages.WM_RBUTTONDBLCLK:
@@ -268,11 +268,11 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                     break;
 
                 case WindowsMessages.WM_MBUTTONDOWN:
-                    MouseEventReceived(MouseEvent.IconMiddleMouseDown);
+                    MouseEventReceived?.Invoke(MouseEvent.IconMiddleMouseDown);
                     break;
 
                 case WindowsMessages.WM_MBUTTONUP:
-                    MouseEventReceived(MouseEvent.IconMiddleMouseUp);
+                    MouseEventReceived?.Invoke(MouseEvent.IconMiddleMouseUp);
                     break;
 
                 case WindowsMessages.WM_MBUTTONDBLCLK:
@@ -280,28 +280,24 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                     break;
 
                 case WindowsMessages.NIN_BALLOONSHOW:
-                    var listener = BalloonToolTipChanged;
-                    listener?.Invoke(true);
+                    BalloonToolTipChanged?.Invoke(true);
                     break;
 
                 case WindowsMessages.NIN_BALLOONHIDE:
                 case WindowsMessages.NIN_BALLOONTIMEOUT:
-                    listener = BalloonToolTipChanged;
-                    listener?.Invoke(false);
+                    BalloonToolTipChanged?.Invoke(false);
                     break;
 
                 case WindowsMessages.NIN_BALLOONUSERCLICK:
-                    MouseEventReceived(MouseEvent.BalloonToolTipClicked);
+                    MouseEventReceived?.Invoke(MouseEvent.BalloonToolTipClicked);
                     break;
 
                 case WindowsMessages.NIN_POPUPOPEN:
-                    listener = ChangeToolTipStateRequest;
-                    listener?.Invoke(true);
+                    ChangeToolTipStateRequest?.Invoke(true);
                     break;
 
                 case WindowsMessages.NIN_POPUPCLOSE:
-                    listener = ChangeToolTipStateRequest;
-                    listener?.Invoke(false);
+                    ChangeToolTipStateRequest?.Invoke(false);
                     break;
 
                 case WindowsMessages.NIN_SELECT:
@@ -361,7 +357,6 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         {
             Dispose(false);
         }
-
 
         /// <summary>
         /// Removes the windows hook that receives window

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
@@ -225,7 +225,9 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         {
             if (msg != CallbackMessageId) return;
 
-            switch ((WindowsMessages)lParam.ToInt32())
+            var message = (WindowsMessages) lParam.ToInt32();
+            Debug.WriteLine("Got message " + message);
+            switch (message)
             {
                 case WindowsMessages.WM_CONTEXTMENU:
                     // TODO: Handle WM_CONTEXTMENU, see https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyiconw
@@ -305,6 +307,11 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                 case WindowsMessages.NIN_SELECT:
                     // TODO: Handle NIN_SELECT see https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyiconw
                     Debug.WriteLine("Unhandled NIN_SELECT");
+                    break;
+
+                case WindowsMessages.NIN_KEYSELECT:
+                    // TODO: Handle NIN_KEYSELECT see https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyiconw
+                    Debug.WriteLine("Unhandled NIN_KEYSELECT");
                     break;
 
                 default:

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs
@@ -227,6 +227,11 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
 
             switch ((WindowsMessages)lParam.ToInt32())
             {
+                case WindowsMessages.WM_CONTEXTMENU:
+                    // TODO: Handle WM_CONTEXTMENU, see https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyiconw
+                    Debug.WriteLine("Unhandled WM_CONTEXTMENU");
+                    break;
+
                 case WindowsMessages.WM_MOUSEMOVE:
                     MouseEventReceived(MouseEvent.MouseMove);
                     break;
@@ -272,29 +277,34 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                     //double click with middle mouse button - do not trigger event
                     break;
 
-                case WindowsMessages.WM_USER2:
+                case WindowsMessages.NIN_BALLOONSHOW:
                     var listener = BalloonToolTipChanged;
                     listener?.Invoke(true);
                     break;
 
-                case WindowsMessages.WM_USER3:
-                case WindowsMessages.WM_USER4:
+                case WindowsMessages.NIN_BALLOONHIDE:
+                case WindowsMessages.NIN_BALLOONTIMEOUT:
                     listener = BalloonToolTipChanged;
                     listener?.Invoke(false);
                     break;
 
-                case WindowsMessages.WM_USER5:
+                case WindowsMessages.NIN_BALLOONUSERCLICK:
                     MouseEventReceived(MouseEvent.BalloonToolTipClicked);
                     break;
 
-                case WindowsMessages.WM_USER6:
+                case WindowsMessages.NIN_POPUPOPEN:
                     listener = ChangeToolTipStateRequest;
                     listener?.Invoke(true);
                     break;
 
-                case WindowsMessages.WM_USER7:
+                case WindowsMessages.NIN_POPUPCLOSE:
                     listener = ChangeToolTipStateRequest;
                     listener?.Invoke(false);
+                    break;
+
+                case WindowsMessages.NIN_SELECT:
+                    // TODO: Handle NIN_SELECT see https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyiconw
+                    Debug.WriteLine("Unhandled NIN_SELECT");
                     break;
 
                 default:

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowsMessages.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowsMessages.cs
@@ -1,28 +1,183 @@
-﻿
+﻿// hardcodet.net NotifyIcon for WPF
+// Copyright (c) 2009 - 2013 Philipp Sumi
+// Contact and Information: http://www.hardcodet.net
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the Code Project Open License (CPOL);
+// either version 1.0 of the License, or (at your option) any later
+// version.
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+// OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+// HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+// WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+//
+// THIS COPYRIGHT NOTICE MAY NOT BE REMOVED FROM THIS FILE
+
 // ReSharper disable InconsistentNaming
-#pragma warning disable 1591
+
+using System.Diagnostics.CodeAnalysis;
 
 namespace Hardcodet.Wpf.TaskbarNotification.Interop
 {
+    /// <summary>
+    /// This enum defines the windows messages we respond to.
+    /// See more on Windows messages <a href="https://docs.microsoft.com/en-us/windows/win32/learnwin32/window-messages">here</a>
+    /// </summary>
+    [SuppressMessage("ReSharper", "IdentifierTypo")]
     public enum WindowsMessages : uint
     {
-        WM_MOUSEMOVE = 0x0200,
-        WM_LBUTTONDOWN = 0x0201,
-        WM_LBUTTONUP = 0x0202,
-        WM_LBUTTONDBLCLK = 0x0203,
-        WM_RBUTTONDOWN = 0x0204,
-        WM_RBUTTONUP = 0x0205,
-        WM_RBUTTONDBLCLK = 0x0206,
-        WM_MBUTTONDOWN = 0x0207,
-        WM_MBUTTONUP = 0x0208,
-        WM_MBUTTONDBLCLK = 0x0209,
-        WM_USER = 0x0400,
-        WM_USER2 = WM_USER + 2,
-        WM_USER3 = WM_USER + 3,
-        WM_USER4 = WM_USER + 4,
-        WM_USER5 = WM_USER + 5,
-        WM_USER6 = WM_USER + 6,
-        WM_USER7 = WM_USER + 7,
+        /// <summary>
+        /// Notifies a window that the user clicked the right mouse button (right-clicked) in the window.
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/menurc/wm-contextmenu">WM_CONTEXTMENU message</a>
+        /// 
+        /// In case of a notify icon: 
+        /// If a user selects a notify icon's shortcut menu with the keyboard, the Shell now sends the associated application a WM_CONTEXTMENU message. Earlier versions send WM_RBUTTONDOWN and WM_RBUTTONUP messages.
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyiconw">Shell_NotifyIcon function</a>
+        /// </summary>
+        WM_CONTEXTMENU = 0x007b,
 
+        /// <summary>
+        /// Posted to a window when the cursor moves.
+        /// If the mouse is not captured, the message is posted to the window that contains the cursor.
+        /// Otherwise, the message is posted to the window that has captured the mouse.
+        ///
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-mousemove">WM_MOUSEMOVE message</a>
+        /// </summary>
+        WM_MOUSEMOVE = 0x0200,
+
+        /// <summary>
+        /// Posted when the user presses the left mouse button while the cursor is in the client area of a window.
+        /// If the mouse is not captured, the message is posted to the window beneath the cursor.
+        /// Otherwise, the message is posted to the window that has captured the mouse.
+        /// 
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-lbuttondown">WM_LBUTTONDOWN message</a>
+        /// </summary>
+        WM_LBUTTONDOWN = 0x0201,
+
+        /// <summary>
+        /// Posted when the user releases the left mouse button while the cursor is in the client area of a window.
+        /// If the mouse is not captured, the message is posted to the window beneath the cursor.
+        /// Otherwise, the message is posted to the window that has captured the mouse.
+        ///
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-lbuttonup">WM_LBUTTONUP message</a>
+        /// </summary>
+        WM_LBUTTONUP = 0x0202,
+
+        /// <summary>
+        /// Posted when the user double-clicks the left mouse button while the cursor is in the client area of a window.
+        /// If the mouse is not captured, the message is posted to the window beneath the cursor.
+        /// Otherwise, the message is posted to the window that has captured the mouse.
+        ///
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-lbuttondblclk">WM_LBUTTONDBLCLK message</a>
+        /// </summary>
+        WM_LBUTTONDBLCLK = 0x0203,
+
+        /// <summary>
+        /// Posted when the user presses the right mouse button while the cursor is in the client area of a window.
+        /// If the mouse is not captured, the message is posted to the window beneath the cursor.
+        /// Otherwise, the message is posted to the window that has captured the mouse.
+        ///
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-rbuttondown">WM_RBUTTONDOWN message</a>
+        /// </summary>
+        WM_RBUTTONDOWN = 0x0204,
+
+        /// <summary>
+        /// Posted when the user releases the right mouse button while the cursor is in the client area of a window.
+        /// If the mouse is not captured, the message is posted to the window beneath the cursor.
+        /// Otherwise, the message is posted to the window that has captured the mouse.
+        ///
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-rbuttonup">WM_RBUTTONUP message</a>
+        /// </summary>
+        WM_RBUTTONUP = 0x0205,
+
+        /// <summary>
+        /// Posted when the user double-clicks the right mouse button while the cursor is in the client area of a window.
+        /// If the mouse is not captured, the message is posted to the window beneath the cursor.
+        /// Otherwise, the message is posted to the window that has captured the mouse.
+        ///
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-rbuttondblclk">WM_RBUTTONDBLCLK message</a>
+        /// </summary>
+        WM_RBUTTONDBLCLK = 0x0206,
+
+        /// <summary>
+        /// Posted when the user presses the middle mouse button while the cursor is in the client area of a window.
+        /// If the mouse is not captured, the message is posted to the window beneath the cursor.
+        /// Otherwise, the message is posted to the window that has captured the mouse.
+        ///
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-mbuttondown">WM_MBUTTONDOWN message</a>
+        /// </summary>
+        WM_MBUTTONDOWN = 0x0207,
+
+        /// <summary>
+        /// Posted when the user releases the middle mouse button while the cursor is in the client area of a window.
+        /// If the mouse is not captured, the message is posted to the window beneath the cursor.
+        /// Otherwise, the message is posted to the window that has captured the mouse.
+        ///
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-mbuttonup">WM_MBUTTONUP message</a>
+        /// </summary>
+        WM_MBUTTONUP = 0x0208,
+
+        /// <summary>
+        /// Posted when the user double-clicks the middle mouse button while the cursor is in the client area of a window.
+        /// If the mouse is not captured, the message is posted to the window beneath the cursor.
+        /// Otherwise, the message is posted to the window that has captured the mouse.
+        ///
+        /// See <a href="https://docs.microsoft.com/en-us/windows/win32/inputdev/wm-mbuttondblclk">WM_MBUTTONDBLCLK message</a>
+        /// </summary>
+        WM_MBUTTONDBLCLK = 0x0209,
+
+        /// <summary>
+        /// Used to define private messages for use by private window classes, usually of the form WM_USER+x, where x is an integer value.
+        /// </summary>
+        WM_USER = 0x0400,
+
+        /// <summary>
+        /// This message is only send when using NOTIFYICON_VERSION_4, the Shell now sends the associated application an NIN_SELECT notification.
+        /// Send when a notify icon is activated with mouse or ENTER key.
+        /// Earlier versions send WM_RBUTTONDOWN and WM_RBUTTONUP messages.
+        /// </summary>
+        NIN_SELECT = WM_USER,
+
+        /// <summary>
+        /// Sent when the balloon is shown (balloons are queued).
+        /// </summary>
+        NIN_BALLOONSHOW = WM_USER + 2,
+
+        /// <summary>
+        /// Sent when the balloon disappears. For example, when the icon is deleted.
+        /// This message is not sent if the balloon is dismissed because of a timeout or if the user clicks the mouse.
+        ///
+        /// As of Windows 7, NIN_BALLOONHIDE is also sent when a notification with the NIIF_RESPECT_QUIET_TIME flag set attempts to display during quiet time (a user's first hour on a new computer).
+        /// In that case, the balloon is never displayed at all.
+        /// </summary>
+        NIN_BALLOONHIDE = WM_USER + 3,
+
+        /// <summary>
+        /// Sent when the balloon is dismissed because of a timeout.
+        /// </summary>
+        NIN_BALLOONTIMEOUT = WM_USER + 4,
+
+        /// <summary>
+        /// Sent when the balloon is dismissed because the user clicked the mouse.
+        /// </summary>
+        NIN_BALLOONUSERCLICK = WM_USER + 5,
+
+        /// <summary>
+        /// Sent when the user hovers the cursor over an icon to indicate that the richer pop-up UI should be used in place of a standard textual tooltip.
+        /// </summary>
+        NIN_POPUPOPEN = WM_USER + 6,
+
+        /// <summary>
+        /// Sent when a cursor no longer hovers over an icon to indicate that the rich pop-up UI should be closed.
+        /// </summary>
+        NIN_POPUPCLOSE = WM_USER + 7
     }
 }

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowsMessages.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowsMessages.cs
@@ -1,0 +1,28 @@
+﻿
+// ReSharper disable InconsistentNaming
+#pragma warning disable 1591
+
+namespace Hardcodet.Wpf.TaskbarNotification.Interop
+{
+    public enum WindowsMessages : uint
+    {
+        WM_MOUSEMOVE = 0x0200,
+        WM_LBUTTONDOWN = 0x0201,
+        WM_LBUTTONUP = 0x0202,
+        WM_LBUTTONDBLCLK = 0x0203,
+        WM_RBUTTONDOWN = 0x0204,
+        WM_RBUTTONUP = 0x0205,
+        WM_RBUTTONDBLCLK = 0x0206,
+        WM_MBUTTONDOWN = 0x0207,
+        WM_MBUTTONUP = 0x0208,
+        WM_MBUTTONDBLCLK = 0x0209,
+        WM_USER = 0x0400,
+        WM_USER2 = WM_USER + 2,
+        WM_USER3 = WM_USER + 3,
+        WM_USER4 = WM_USER + 4,
+        WM_USER5 = WM_USER + 5,
+        WM_USER6 = WM_USER + 6,
+        WM_USER7 = WM_USER + 7,
+
+    }
+}

--- a/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowsMessages.cs
+++ b/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowsMessages.cs
@@ -147,6 +147,13 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         NIN_SELECT = WM_USER,
 
         /// <summary>
+        /// This message is only send when using NOTIFYICON_VERSION_4, the Shell now sends the associated application an NIN_SELECT notification.
+        /// Send when a notify icon is activated with SPACEBAR or ENTER key.
+        /// Earlier versions send WM_RBUTTONDOWN and WM_RBUTTONUP messages.
+        /// </summary>
+        NIN_KEYSELECT = WM_USER + 1,
+
+        /// <summary>
         /// Sent when the balloon is shown (balloons are queued).
         /// </summary>
         NIN_BALLOONSHOW = WM_USER + 2,


### PR DESCRIPTION
@hardcodet 
I dislike constants which I cannot understand, so I made a quick change to use an enum for the windows messages. 

Than I noticed that I cannot find the ones here: https://github.com/hardcodet/wpf-notifyicon/blob/master/Hardcodet.NotifyIcon.Wpf/Source/NotifyIconWpf/Interop/WindowMessageSink.cs#L280
I know the user messages start with 0x0400, but I have no idea where you got the id's from and what they mean. Any chance you could document them?