### PR TITLE
Fix taskbar restarting issue

### DIFF
--- a/src/NotifyIconWpf/TaskbarIcon.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.cs
@@ -931,7 +931,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// </summary>
         private void OnTaskbarCreated()
         {
-            IsTaskbarIconCreated = false;
+            RemoveTaskbarIcon();
             CreateTaskbarIcon();
         }
 


### PR DESCRIPTION
#### Bug description

The taskbar icon stays open.

#### Repro steps

Run Notification sample program, set the notify icon active. Open Display settings, and change the monitor's scaling (which causes recreating taskbar).

The notify icon stays open even if I close the notify icon.
