### PR TITLE
Support for building under .NET 3.0.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -22,6 +22,10 @@ Source code and extensive sample application available at http://www.hardcodet.n
     <tags>NotifyIcon WPF Tray Notify ToolTip Popup Balloon Toast</tags>
   </PropertyGroup>
 
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('net3'))">
+    <EmitThisAssemblyClass>false</EmitThisAssemblyClass>
+  </PropertyGroup>
+
   <PropertyGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
@@ -49,12 +53,13 @@ Source code and extensive sample application available at http://www.hardcodet.n
       </PropertyGroup>
 
       <ItemGroup>
-        <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.91">
+        <PackageReference Condition="!$(TargetFramework.StartsWith('net3'))"
+                          Include="Nerdbank.GitVersioning" Version="3.1.91">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-        <None Include="$(SolutionDir)\icon.png" Pack="true" PackagePath="\"/>
+        <None Include="..\icon.png" Pack="true" PackagePath="\"/>
       </ItemGroup>
 
       <!-- SourceLink -->

--- a/src/NotifyIconWpf/NotifyIconWpf.csproj
+++ b/src/NotifyIconWpf/NotifyIconWpf.csproj
@@ -4,15 +4,17 @@
     <AssemblyName>Hardcodet.NotifyIcon.Wpf</AssemblyName>
     <AssemblyTitle>NotifyIcon for WPF</AssemblyTitle>
     <Product>NotifyIcon WPF</Product>
-    <TargetFrameworks>net45;net472;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net30;net45;net472;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net45'">
+  <ItemGroup Condition="('$(TargetFramework)' != 'net45') And ('$(TargetFramework)' != 'net30')">
     <PackageReference Include="System.Resources.Extensions" Version="4.7.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net4'))">
     <Reference Include="System.Xaml" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net3')) Or $(TargetFramework.StartsWith('net4'))">
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/src/NotifyIconWpf/NotifyIconWpf.csproj
+++ b/src/NotifyIconWpf/NotifyIconWpf.csproj
@@ -4,7 +4,7 @@
     <AssemblyName>Hardcodet.NotifyIcon.Wpf</AssemblyName>
     <AssemblyTitle>NotifyIcon for WPF</AssemblyTitle>
     <Product>NotifyIcon WPF</Product>
-    <TargetFrameworks>net30;net45;net472;netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net30</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="('$(TargetFramework)' != 'net45') And ('$(TargetFramework)' != 'net30')">

--- a/src/NotifyIconWpf/Util.cs
+++ b/src/NotifyIconWpf/Util.cs
@@ -32,6 +32,24 @@ using System.Windows.Resources;
 using System.Windows.Threading;
 using Hardcodet.Wpf.TaskbarNotification.Interop;
 
+#if NET30
+/// <summary>
+/// Implement the generic Action type which only appeared in .NET 3.5
+/// </summary>
+public delegate void Action();
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Make the ExtensionAttribute compiler feature visible
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false, Inherited = false)]
+    internal class ExtensionAttribute : Attribute
+    {
+    }
+}
+#endif
+
 namespace Hardcodet.Wpf.TaskbarNotification
 {
     /// <summary>


### PR DESCRIPTION
Hi! I don’t think this PR is good enough to be integrated, but maybe if others are still targeting .NET 3.0 they may find it useful.

The reason I target that framework is because I have software that Windows XP users still use.