### PR TITLE
Add initial hooks for keyboard-related events.

### DIFF
--- a/src/NotifyIconWpf/Interop/KeyboardEvent.cs
+++ b/src/NotifyIconWpf/Interop/KeyboardEvent.cs
@@ -1,0 +1,26 @@
+﻿namespace Hardcodet.Wpf.TaskbarNotification.Interop
+{
+    /// <summary>
+    /// Event flags for keyboard events.
+    /// </summary>
+    public enum KeyboardEvent
+    {
+        /// <summary>
+        /// The icon was selected with the keyboard
+        /// and Shift-F10 was pressed.
+        /// </summary>
+        ContextMenu,
+
+        /// <summary>
+        /// The icon was selected with the keyboard
+        /// and activated with Spacebar or Enter.
+        /// </summary>
+        KeySelect,
+
+        /// <summary>
+        /// The icon was selected with the mouse
+        /// and activated with Enter.
+        /// </summary>
+        Select,
+    }
+}

--- a/src/NotifyIconWpf/Interop/WindowMessageSink.cs
+++ b/src/NotifyIconWpf/Interop/WindowMessageSink.cs
@@ -95,6 +95,12 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         public event Action<MouseEvent> MouseEventReceived;
 
         /// <summary>
+        /// Fired in case the user interacted with the taskbar
+        /// icon area with keyboard shortcuts.
+        /// </summary>
+        public event Action<KeyboardEvent> KeyboardEventReceived;
+
+        /// <summary>
         /// Fired if a balloon ToolTip was either displayed
         /// or closed (indicated by the boolean flag).
         /// </summary>
@@ -242,8 +248,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
             switch (message)
             {
                 case WindowsMessages.WM_CONTEXTMENU:
-                    // TODO: Handle WM_CONTEXTMENU, see https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyiconw
-                    Debug.WriteLine("Unhandled WM_CONTEXTMENU");
+                    KeyboardEventReceived?.Invoke(KeyboardEvent.ContextMenu);
                     break;
 
                 case WindowsMessages.WM_MOUSEMOVE:
@@ -313,13 +318,11 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                     break;
 
                 case WindowsMessages.NIN_SELECT:
-                    // TODO: Handle NIN_SELECT see https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyiconw
-                    Debug.WriteLine("Unhandled NIN_SELECT");
+                    KeyboardEventReceived?.Invoke(KeyboardEvent.Select);
                     break;
 
                 case WindowsMessages.NIN_KEYSELECT:
-                    // TODO: Handle NIN_KEYSELECT see https://docs.microsoft.com/en-us/windows/win32/api/shellapi/nf-shellapi-shell_notifyiconw
-                    Debug.WriteLine("Unhandled NIN_KEYSELECT");
+                    KeyboardEventReceived?.Invoke(KeyboardEvent.KeySelect);
                     break;
 
                 default:

--- a/src/NotifyIconWpf/TaskbarIcon.Declarations.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.Declarations.cs
@@ -1186,6 +1186,126 @@ namespace Hardcodet.Wpf.TaskbarNotification
 
         #endregion
 
+        #region TrayKeyboardContextMenu
+
+        /// <summary>
+        /// TrayKeyboardContextMenu Routed Event
+        /// </summary>
+        public static readonly RoutedEvent TrayKeyboardContextMenuEvent = EventManager.RegisterRoutedEvent("TrayKeyboardContextMenu",
+            RoutingStrategy.Bubble, typeof (RoutedEventHandler), typeof (TaskbarIcon));
+
+        /// <summary>
+        /// Occurs when the user moves the mouse over the taskbar icon.
+        /// </summary>
+        public event RoutedEventHandler TrayKeyboardContextMenu
+        {
+            add { AddHandler(TrayKeyboardContextMenuEvent, value); }
+            remove { RemoveHandler(TrayKeyboardContextMenuEvent, value); }
+        }
+
+        /// <summary>
+        /// A helper method to raise the TrayKeyboardContextMenu event.
+        /// </summary>
+        protected RoutedEventArgs RaiseTrayKeyboardContextMenuEvent()
+        {
+            return RaiseTrayKeyboardContextMenuEvent(this);
+        }
+
+        /// <summary>
+        /// A static helper method to raise the TrayKeyboardContextMenu event on a target element.
+        /// </summary>
+        /// <param name="target">UIElement or ContentElement on which to raise the event</param>
+        internal static RoutedEventArgs RaiseTrayKeyboardContextMenuEvent(DependencyObject target)
+        {
+            if (target == null) return null;
+
+            RoutedEventArgs args = new RoutedEventArgs(TrayKeyboardContextMenuEvent);
+            RoutedEventHelper.RaiseEvent(target, args);
+            return args;
+        }
+
+        #endregion
+
+        #region TrayKeyboardKeySelect
+
+        /// <summary>
+        /// TrayKeyboardKeySelect Routed Event
+        /// </summary>
+        public static readonly RoutedEvent TrayKeyboardKeySelectEvent = EventManager.RegisterRoutedEvent("TrayKeyboardKeySelect",
+            RoutingStrategy.Bubble, typeof (RoutedEventHandler), typeof (TaskbarIcon));
+
+        /// <summary>
+        /// Occurs when the user moves the mouse over the taskbar icon.
+        /// </summary>
+        public event RoutedEventHandler TrayKeyboardKeySelect
+        {
+            add { AddHandler(TrayKeyboardKeySelectEvent, value); }
+            remove { RemoveHandler(TrayKeyboardKeySelectEvent, value); }
+        }
+
+        /// <summary>
+        /// A helper method to raise the TrayKeyboardKeySelect event.
+        /// </summary>
+        protected RoutedEventArgs RaiseTrayKeyboardKeySelectEvent()
+        {
+            return RaiseTrayKeyboardKeySelectEvent(this);
+        }
+
+        /// <summary>
+        /// A static helper method to raise the TrayKeyboardKeySelect event on a target element.
+        /// </summary>
+        /// <param name="target">UIElement or ContentElement on which to raise the event</param>
+        internal static RoutedEventArgs RaiseTrayKeyboardKeySelectEvent(DependencyObject target)
+        {
+            if (target == null) return null;
+
+            RoutedEventArgs args = new RoutedEventArgs(TrayKeyboardKeySelectEvent);
+            RoutedEventHelper.RaiseEvent(target, args);
+            return args;
+        }
+
+        #endregion
+
+        #region TrayKeyboardSelect
+
+        /// <summary>
+        /// TrayKeyboardSelect Routed Event
+        /// </summary>
+        public static readonly RoutedEvent TrayKeyboardSelectEvent = EventManager.RegisterRoutedEvent("TrayKeyboardSelect",
+            RoutingStrategy.Bubble, typeof (RoutedEventHandler), typeof (TaskbarIcon));
+
+        /// <summary>
+        /// Occurs when the user moves the mouse over the taskbar icon.
+        /// </summary>
+        public event RoutedEventHandler TrayKeyboardSelect
+        {
+            add { AddHandler(TrayKeyboardSelectEvent, value); }
+            remove { RemoveHandler(TrayKeyboardSelectEvent, value); }
+        }
+
+        /// <summary>
+        /// A helper method to raise the TrayKeyboardSelect event.
+        /// </summary>
+        protected RoutedEventArgs RaiseTrayKeyboardSelectEvent()
+        {
+            return RaiseTrayKeyboardSelectEvent(this);
+        }
+
+        /// <summary>
+        /// A static helper method to raise the TrayKeyboardSelect event on a target element.
+        /// </summary>
+        /// <param name="target">UIElement or ContentElement on which to raise the event</param>
+        internal static RoutedEventArgs RaiseTrayKeyboardSelectEvent(DependencyObject target)
+        {
+            if (target == null) return null;
+
+            RoutedEventArgs args = new RoutedEventArgs(TrayKeyboardSelectEvent);
+            RoutedEventHelper.RaiseEvent(target, args);
+            return args;
+        }
+
+        #endregion
+
         #region TrayBalloonTipShown
 
         /// <summary>

--- a/src/NotifyIconWpf/TaskbarIcon.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.cs
@@ -132,6 +132,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
 
             // register event listeners
             messageSink.MouseEventReceived += OnMouseEvent;
+            messageSink.KeyboardEventReceived += OnKeyboardEvent;
             messageSink.TaskbarCreated += OnTaskbarCreated;
             messageSink.ChangeToolTipStateRequest += OnToolTipChange;
             messageSink.BalloonToolTipChanged += OnBalloonToolTipChanged;
@@ -481,6 +482,37 @@ namespace Hardcodet.Wpf.TaskbarNotification
 
         #endregion
 
+        #region Process Incoming Keyboard Events
+
+        /// <summary>
+        /// Processes keyboard events, which are bubbled
+        /// through the class' routed events, trigger
+        /// certain actions (e.g. show a popup), or
+        /// both.
+        /// </summary>
+        /// <param name="ke">Event flag.</param>
+        private void OnKeyboardEvent(KeyboardEvent ke)
+        {
+            if (IsDisposed) return;
+
+            switch (ke)
+            {
+                case KeyboardEvent.ContextMenu:
+                    RaiseTrayKeyboardContextMenuEvent();
+                    break;
+                case KeyboardEvent.KeySelect:
+                    RaiseTrayKeyboardKeySelectEvent();
+                    break;
+                case KeyboardEvent.Select:
+                    RaiseTrayKeyboardSelectEvent();
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(ke), "Missing handler for keyboard event flag: " + ke);
+            }
+        }
+
+        #endregion
+
         #region ToolTips
 
         /// <summary>
@@ -761,6 +793,8 @@ namespace Hardcodet.Wpf.TaskbarNotification
             // does not close if the user clicks somewhere else. With the message window
             // fallback, the context menu can't receive keyboard events - should not happen though
             WinApi.SetForegroundWindow(handle);
+
+            ContextMenu.Focus();
 
             // bubble event
             RaiseTrayContextMenuOpenEvent();


### PR DESCRIPTION
This is the first step to implement keyboard interaction using the standard <kbd>Win</kbd>+<kbd>B</kbd>, <kbd>Ctrl</kbd>+<kbd>F10</kbd>, <kbd>Enter</kbd>, etc. shortcuts.

Going further will require more work:
 - something similar to https://github.com/hardcodet/wpf-notifyicon/pull/32 so that `WM_CONTEXTMENU` can open the context menu next to the icon rather than under the mouse cursor
 - handle `NIN_KEYSELECT` being received twice in a row (when <kbd>Enter</kbd> is used), maybe using a timer similar to `TaskBarIcon.singleClickTimer`