### PR TITLE
Update TaskbarIcon.Declarations.cs

### DIFF
--- a/src/NotifyIconWpf/TaskbarIcon.Declarations.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.Declarations.cs
@@ -248,6 +248,46 @@ namespace Hardcodet.Wpf.TaskbarNotification
         }
 
         #endregion
+            
+        #region IconInMemory
+
+        /// <summary>
+        /// Updates the <see cref="Icon" /> property.
+        /// </summary>
+        public static readonly DependencyProperty IconInMemoryProperty =
+            DependencyProperty.Register(nameof(IconInMemory),
+                typeof(Icon),
+                typeof(TaskbarIcon),
+                new FrameworkPropertyMetadata(null, IconInMemoryPropertyChanged));
+
+        /// <summary>
+        /// A property wrapper for the <see cref="IconInMemory"/>
+        /// dependency property:<br/>
+        /// Updates the <see cref="Icon" /> property.
+        /// </summary>
+        [Category(CategoryName)]
+        [Description("Sets the displayed taskbar icon.")]
+        public Icon IconInMemory
+        {
+            get { return (Icon)GetValue(IconInMemoryProperty); }
+            set { SetValue(IconInMemoryProperty, value); }
+        }
+
+        private static void IconInMemoryPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            TaskbarIcon owner = (TaskbarIcon)d;
+            owner.OnIconInMemoryPropertyChanged(e);
+        }
+
+        private void OnIconInMemoryPropertyChanged(DependencyPropertyChangedEventArgs e)
+        {
+            Icon newValue = (Icon)e.NewValue;
+
+            //resolving the ImageSource at design time is unlikely to work
+            if (!Util.IsDesignMode) Icon = newValue;
+        }
+
+        #endregion
 
         #region ToolTipText dependency property
 


### PR DESCRIPTION
Added support for dynamic, in-memory icons to be assigned at the xaml level. This allows better support for MVVM design.

For a small wpf project I created, I wanted the ability to generate icons at runtime, while maintaining MVVM design pattern. The only way I could figure out how to assign dynamic in-memory icons was to break MVVM and access the TaskbarIcon object directly in the ViewModel code. So I added this ability which worked well for my needs, and thought I'd share if you are interested in it.

Usage in xaml:

            <tb:TaskbarIcon
                x:Name ="ToolbarIcon"
                **IconInMemory="{Binding TrayIcon}"**
               ... />

In ViewModel (where TrayIcon is set via dynamic icon generation):
        public Icon TrayIcon
        {
            get
            {
                return _trayIcon;
            }
            set
            {
                _trayIcon = value;
                NotifyPropertyChanged(nameof(TrayIcon));
            }
        }