### PR TITLE
Allow IconSource to be a concrete BitmapSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ The sample below shows some of the properties of the control. For a more compreh
 </Window>
 ```
 
+## Contributors and Thanks
+
+Hi, I'm Philipp! This little library was originally written by me, but is currently mostly maintained by [Jan Karger](https://github.com/punker76) and [Robin Krom](https://github.com/Lakritzator). Big, big kudos to the two of you, and everybody else who [contributed](https://github.com/hardcodet/wpf-notifyicon/graphs/contributors) to this library. You rock!
+
+Make sure to check out Robin's great [Greenshot](https://getgreenshot.org/) tool (that I use on a daily basis), and Jan's [MahApps](https://github.com/MahApps) UI framework.
+

--- a/src/NotifyIconWpf/Util.cs
+++ b/src/NotifyIconWpf/Util.cs
@@ -25,9 +25,11 @@
 using System;
 using System.ComponentModel;
 using System.Drawing;
+using System.IO;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Imaging;
 using System.Windows.Resources;
 using System.Windows.Threading;
 using Hardcodet.Wpf.TaskbarNotification.Interop;
@@ -156,7 +158,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
 
         #endregion
 
-        #region ImageSource to Icon
+        #region ToIcon Extensions
 
         /// <summary>
         /// Reads a given image resource into a WinForms icon.
@@ -169,6 +171,8 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             if (imageSource == null) return null;
 
+            if (imageSource is BitmapImage bmp) return bmp.ToIcon();
+
             Uri uri = new Uri(imageSource.ToString());
             StreamResourceInfo streamInfo = Application.GetResourceStream(uri);
 
@@ -180,6 +184,24 @@ namespace Hardcodet.Wpf.TaskbarNotification
             }
 
             return new Icon(streamInfo.Stream);
+        }
+
+        /// <summary>
+        /// Converts a System.Windows.Media.Imaging.BitmapSource to
+        /// a System.Drawing.Icon.
+        /// </summary>
+        /// <param name="bitmap">The System.Windows.Media.Imaging bitmap.</param>
+        /// <returns>System.Drawing.Icon.</returns>
+        public static Icon ToIcon(this BitmapSource bitmap)
+        {
+            var enc = new BmpBitmapEncoder();
+            enc.Frames.Add(BitmapFrame.Create(bitmap));
+
+            var stream = new MemoryStream();
+            enc.Save(stream);
+
+            var bmp = new Bitmap(stream);
+            return Icon.FromHandle(bmp.GetHicon());
         }
 
         #endregion

--- a/src/NotifyIconWpf/Util.cs
+++ b/src/NotifyIconWpf/Util.cs
@@ -197,11 +197,12 @@ namespace Hardcodet.Wpf.TaskbarNotification
             var enc = new BmpBitmapEncoder();
             enc.Frames.Add(BitmapFrame.Create(bitmap));
 
-            var stream = new MemoryStream();
+            using var stream = new MemoryStream();
             enc.Save(stream);
 
-            var bmp = new Bitmap(stream);
-            return Icon.FromHandle(bmp.GetHicon());
+            using var bmp = new Bitmap(stream);
+            using var icon = Icon.FromHandle(bmp.GetHicon());
+            return icon;
         }
 
         #endregion


### PR DESCRIPTION
By adding a BitmapSource.ToIcon extension method to util.cs, along a check in ImageSource.ToIcon to look for the concrete type and call said method, the IconSource can be bound to a concrete BitmapSource type.  This allows for dynamic drawing of the icon image by my application.

There may be better ways to do this, but this seemed pretty simple.