### PR TITLE
Fixed #75: Pick the correct size of the icon from a .ico file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,9 @@ The sample below shows some of the properties of the control. For a more compreh
 </Window>
 ```
 
+## Contributors and Thanks
+
+Hi, I'm Philipp! This little library was originally written by me, but is currently mostly maintained by [Jan Karger](https://github.com/punker76) and [Robin Krom](https://github.com/Lakritzator). Big, big kudos to the two of you, and everybody else who [contributed](https://github.com/hardcodet/wpf-notifyicon/graphs/contributors) to this library. You rock!
+
+Make sure to check out Robin's great [Greenshot](https://getgreenshot.org/) tool (that I use on a daily basis), and Jan's [MahApps](https://github.com/MahApps) UI framework.
+

--- a/src/NotifyIconWpf/Interop/Size.cs
+++ b/src/NotifyIconWpf/Interop/Size.cs
@@ -1,0 +1,20 @@
+﻿using System.Runtime.InteropServices;
+
+namespace Hardcodet.Wpf.TaskbarNotification.Interop
+{
+    /// <summary>
+    /// Win API struct representing a size with width and height.
+    /// </summary>
+    [StructLayout(LayoutKind.Sequential)]
+    public struct Size
+    {
+        /// <summary>
+        /// Width.
+        /// </summary>
+        public int Width;
+        /// <summary>
+        /// Height.
+        /// </summary>
+        public int Height;
+    }
+}

--- a/src/NotifyIconWpf/Interop/SystemInfo.cs
+++ b/src/NotifyIconWpf/Interop/SystemInfo.cs
@@ -81,5 +81,50 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                 Y = (int)(point.Y / DpiFactorY)
             };
         }
+
+        /// <summary>
+        /// Scale the supplied size to the current DPI settings
+        /// </summary>
+        /// <param name="size"></param>
+        /// <returns>Size</returns>
+        [Pure]
+        public static Size ScaleWithDpi(this Size size)
+        {
+            return new Size
+            {
+                Height = (int)(size.Height / DpiFactorX),
+                Width = (int)(size.Width / DpiFactorY)
+            };
+        }
+
+        #region SmallIconSize
+
+        private static Size? _smallIconSize = null;
+
+        private const int CXSMICON = 49;
+        private const int CYSMICON = 50;
+
+        /// <summary>
+        /// Gets a value indicating the recommended size, in pixels, of a small icon
+        /// </summary>
+        public static Size SmallIconSize
+        {
+            get
+            {
+                if (!_smallIconSize.HasValue)
+                {
+                    Size smallIconSize = new Size
+                    {
+                        Height = WinApi.GetSystemMetrics(CYSMICON),
+                        Width = WinApi.GetSystemMetrics(CXSMICON)
+                    };
+                    _smallIconSize = smallIconSize.ScaleWithDpi();
+                }
+
+                return _smallIconSize.Value;
+            }
+        }
+
+        #endregion
     }
 }

--- a/src/NotifyIconWpf/Interop/SystemInfo.cs
+++ b/src/NotifyIconWpf/Interop/SystemInfo.cs
@@ -92,8 +92,8 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         {
             return new Size
             {
-                Height = (int)(size.Height / DpiFactorX),
-                Width = (int)(size.Width / DpiFactorY)
+                Height = (int)(size.Height / DpiFactorY),
+                Width = (int)(size.Width / DpiFactorX)
             };
         }
 

--- a/src/NotifyIconWpf/Interop/WinApi.cs
+++ b/src/NotifyIconWpf/Interop/WinApi.cs
@@ -87,5 +87,12 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
 
         [DllImport(User32, SetLastError = true)]
         public static extern bool GetCursorPos(ref Point lpPoint);
+
+
+        /// <summary>
+        /// Gets the specified system metric.
+        /// </summary>
+        [DllImport(User32)]
+        internal static extern int GetSystemMetrics(int nIndex);
     }
 }

--- a/src/NotifyIconWpf/Interop/WinApi.cs
+++ b/src/NotifyIconWpf/Interop/WinApi.cs
@@ -89,12 +89,6 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
         public static extern bool GetCursorPos(ref Point lpPoint);
 
         /// <summary>
-        /// Gets the specified system metric.
-        /// </summary>
-        [DllImport(User32)]
-        internal static extern int GetSystemMetrics(int nIndex);
-
-        /// <summary>
         /// Gets the screen coordinates of the current mouse position.
         /// in device coordinates
         /// </summary>
@@ -116,5 +110,12 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
 
             return TrayInfo.GetDeviceCoordinates(cursorPosition);
         }
+
+
+        /// <summary>
+        /// Gets the specified system metric.
+        /// </summary>
+        [DllImport(User32)]
+        internal static extern int GetSystemMetrics(int nIndex);
     }
 }

--- a/src/NotifyIconWpf/Util.cs
+++ b/src/NotifyIconWpf/Util.cs
@@ -179,7 +179,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
                 throw new ArgumentException(msg);
             }
 
-            return new Icon(streamInfo.Stream);
+            return new Icon(streamInfo.Stream, new System.Drawing.Size((int)SystemParameters.SmallIconWidth, (int)SystemParameters.SmallIconHeight));
         }
 
         #endregion

--- a/src/NotifyIconWpf/Util.cs
+++ b/src/NotifyIconWpf/Util.cs
@@ -179,7 +179,8 @@ namespace Hardcodet.Wpf.TaskbarNotification
                 throw new ArgumentException(msg);
             }
 
-            return new Icon(streamInfo.Stream, new System.Drawing.Size((int)SystemParameters.SmallIconWidth, (int)SystemParameters.SmallIconHeight));
+            Interop.Size iconSize = SystemInfo.SmallIconSize;
+            return new Icon(streamInfo.Stream, new System.Drawing.Size(iconSize.Width, iconSize.Height));
         }
 
         #endregion


### PR DESCRIPTION
As explained in #75, if a .ico file with multiple icons is used, the wrong size of the icon is picked and downscaled to the requested size.

This PR fixed that problem by sending the requested icon size when creating the icon.

Downscaled wrong icon:  
![tray](https://user-images.githubusercontent.com/32025549/168428227-d1e06336-7818-4a07-a7e1-136625e73102.png)

Right icon:  
![tray2](https://user-images.githubusercontent.com/32025549/168428300-96459da6-ef95-4fea-b21c-069328e29975.png)

Tested on Windows 11 with .NET 6.0.