### PR TITLE
Fixed #77, changed NIN_SELECT to trigger the mouse click event.

### DIFF
--- a/src/NotifyIconWpf/Interop/WindowMessageSink.cs
+++ b/src/NotifyIconWpf/Interop/WindowMessageSink.cs
@@ -248,7 +248,6 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
             switch (message)
             {
                 case WindowsMessages.WM_CONTEXTMENU:
-                case WindowsMessages.NIN_SELECT:
                 case WindowsMessages.NIN_KEYSELECT:
                     /*
                      * GET_X_LPARAM should be used to retrieve anchor X-coordinate, this is defined as
@@ -271,6 +270,8 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                     MouseEventReceived?.Invoke(MouseEvent.IconLeftMouseDown);
                     break;
 
+                case WindowsMessages.NIN_SELECT:
+                    //Sent when the icon is selected with the left mouse button.
                 case WindowsMessages.WM_LBUTTONUP:
                     if (!isDoubleClick)
                     {


### PR DESCRIPTION
After a few tests I've concluded that imo the right place for NIN_SELECT is when a mouse click event is complete (at WM_LBUTTONUP).  
Tested on Win10 and Win11, NIN_SELECT is triggered only when clicking the icon with the mouse left button.

The mouse right button triggers WM_CONTEXTMENU, and the enter key triggers NIN_KEYSELECT.

This fixes the problem that the context menu is always opened when clicking with the mouse #77, now it follows the same behaviour specified for the left mouse button.

fix #77 