### PR TITLE
ContextMenu is fired twice and ends up never showing up

### DIFF
--- a/src/NotifyIconWpf/TaskbarIcon.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.cs
@@ -433,11 +433,6 @@ namespace Hardcodet.Wpf.TaskbarNotification
                     singleClickTimer.Change(DoubleClickWaitTime, Timeout.Infinite);
                     isLeftClickCommandInvoked = true;
                 }
-                else
-                {
-                    // show context menu immediately
-                    ShowContextMenu(cursorPosition);
-                }
             }
 
             // make sure the left click command is invoked on mouse clicks


### PR DESCRIPTION
Context: https://github.com/hardcodet/wpf-notifyicon/issues/79

Didn't see any contribution instructions, so I just changed it in develop. Is this ok?