### PR TITLE
Improve `TaskbarIcon.Dispose`

### DIFF
--- a/src/NotifyIconWpf/TaskbarIcon.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.cs
@@ -1104,7 +1104,8 @@ namespace Hardcodet.Wpf.TaskbarNotification
                 // de-register application event listener
                 if (Application.Current != null)
                 {
-                    Application.Current.Exit -= OnExit;
+                    // Dispose may be called by any thread, so we need to dispatch the event access to the correct thread.
+                    Application.Current.Dispatcher.Invoke(() => Application.Current.Exit -= OnExit);
                 }
 
                 // stop timers

--- a/src/NotifyIconWpf/TaskbarIcon.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.cs
@@ -1092,7 +1092,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// be disposed.</param>
         /// <remarks>Check the <see cref="IsDisposed"/> property to determine whether
         /// the method has already been called.</remarks>
-        private void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             // don't do anything if the component is already disposed
             if (IsDisposed || !disposing) return;


### PR DESCRIPTION
* Allow overriding `Dispose(bool)` as per the documentation on `Dispose()` (fixes #91)
* Perform the deregistration of the `Application.Exit` event on the application instance's dispatcher to avoid threading/ownership exceptions (fixes #92)