### PR TITLE
Fix side-effect of Microsoft bringing back support for pre-Windows 11 custom tooltips

### DIFF
--- a/src/NotifyIconWpf/TaskbarIcon.Declarations.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.Declarations.cs
@@ -189,7 +189,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
                 icon = value;
                 iconData.IconHandle = value == null ? IntPtr.Zero : icon.Handle;
 
-                Util.WriteIconData(ref iconData, NotifyCommand.Modify, IconDataMembers.Icon);
+                Util.WriteIconData(ref iconData, NotifyCommand.Modify, WithTrayToolTip(IconDataMembers.Icon));
             }
         }
 

--- a/src/NotifyIconWpf/TaskbarIcon.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.cs
@@ -91,6 +91,11 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// </summary>
         public bool SupportsCustomToolTips => messageSink.Version == NotifyIconVersion.Vista;
 
+        /// <summary>
+        /// Indicates that ToolTipText should be displayed.
+        /// </summary>
+        private bool showSystemToolTip = false;
+
 
         /// <summary>
         /// Checks whether a non-tooltip popup is currently opened.
@@ -554,14 +559,6 @@ namespace Hardcodet.Wpf.TaskbarNotification
                     Content = TrayToolTip
                 };
             }
-            else if (tt == null && !string.IsNullOrEmpty(ToolTipText))
-            {
-                // create a simple tooltip for the ToolTipText string
-                tt = new ToolTip
-                {
-                    Content = ToolTipText
-                };
-            }
 
             // the tooltip explicitly gets the DataContext of this instance.
             // If there is no DataContext, the TaskbarIcon assigns itself
@@ -582,7 +579,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         /// <returns>Flags amended with NIF_SHOWTIP if required.</returns>
         private IconDataMembers WithTrayToolTip(IconDataMembers flags)
         {
-            if (TrayToolTip is null)
+            if (showSystemToolTip)
             {
                 flags |= IconDataMembers.UseLegacyToolTips;
             }
@@ -598,6 +595,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
         {
             const IconDataMembers flags = IconDataMembers.Tip;
             iconData.ToolTipText = ToolTipText;
+            showSystemToolTip = TrayToolTip is null;
 
             if (messageSink.Version == NotifyIconVersion.Vista)
             {

--- a/src/NotifyIconWpf/TaskbarIcon.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.cs
@@ -574,6 +574,21 @@ namespace Hardcodet.Wpf.TaskbarNotification
             SetTrayToolTipResolved(tt);
         }
 
+        /// <summary>
+        /// Shell_NotifyIcon requires NIF_SHOWTIP to be specified for every call to Shell_NotifyIcon.
+        /// This modifies <paramref name="flags"/> to include this if required.
+        /// </summary>
+        /// <param name="flags">Passed through flags fo Shell_NotifyIcon.</param>
+        /// <returns>Flags amended with NIF_SHOWTIP if required.</returns>
+        private IconDataMembers WithTrayToolTip(IconDataMembers flags)
+        {
+            if (TrayToolTip is null)
+            {
+                flags |= IconDataMembers.UseLegacyToolTips;
+            }
+
+            return flags;
+        }
 
         /// <summary>
         /// Sets tooltip settings for the class depending on defined
@@ -597,7 +612,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
             }
 
             // update the tooltip text
-            Util.WriteIconData(ref iconData, NotifyCommand.Modify, flags);
+            Util.WriteIconData(ref iconData, NotifyCommand.Modify, WithTrayToolTip(flags));
         }
 
         #endregion
@@ -871,7 +886,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
 
             iconData.BalloonFlags = flags;
             iconData.CustomBalloonIconHandle = balloonIconHandle;
-            Util.WriteIconData(ref iconData, NotifyCommand.Modify, IconDataMembers.Info | IconDataMembers.Icon);
+            Util.WriteIconData(ref iconData, NotifyCommand.Modify, WithTrayToolTip(IconDataMembers.Info | IconDataMembers.Icon));
         }
 
 
@@ -884,7 +899,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
 
             // reset balloon by just setting the info to an empty string
             iconData.BalloonText = iconData.BalloonTitle = string.Empty;
-            Util.WriteIconData(ref iconData, NotifyCommand.Modify, IconDataMembers.Info);
+            Util.WriteIconData(ref iconData, NotifyCommand.Modify, WithTrayToolTip(IconDataMembers.Info));
         }
 
         #endregion
@@ -975,7 +990,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
                                                 | IconDataMembers.Tip;
 
                 //write initial configuration
-                var status = Util.WriteIconData(ref iconData, NotifyCommand.Add, members);
+                var status = Util.WriteIconData(ref iconData, NotifyCommand.Add, WithTrayToolTip(members));
                 if (!status)
                 {
                     // couldn't create the icon - we can assume this is because explorer is not running (yet!)
@@ -1007,7 +1022,7 @@ namespace Hardcodet.Wpf.TaskbarNotification
                     return;
                 }
 
-                Util.WriteIconData(ref iconData, NotifyCommand.Delete, IconDataMembers.Message);
+                Util.WriteIconData(ref iconData, NotifyCommand.Delete, WithTrayToolTip(IconDataMembers.Message));
                 IsTaskbarIconCreated = false;
             }
         }


### PR DESCRIPTION
Using the WPF tooltip control for showing tool tip text feels out of place on Windows 11, as basic text based tooltips should be displayed using the `NIF_SHOWTIP` flag.

Fixes #95.

TrayToolTipResolved might be removable completely now.