### PR TITLE
Add BalloonClosed event for custom balloon

### DIFF
--- a/src/NotifyIconWpf/TaskbarIcon.Declarations.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.Declarations.cs
@@ -1949,6 +1949,50 @@ namespace Hardcodet.Wpf.TaskbarNotification
 
         #endregion
 
+        #region BalloonClosed
+
+        /// <summary>
+        /// BalloonClosed Attached Routed Event
+        /// </summary>
+        public static readonly RoutedEvent BalloonClosedEvent = EventManager.RegisterRoutedEvent("BalloonClosed",
+            RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(TaskbarIcon));
+
+        /// <summary>
+        /// Adds a handler for the BalloonClosed attached event
+        /// </summary>
+        /// <param name="element">UIElement or ContentElement that listens to the event</param>
+        /// <param name="handler">Event handler to be added</param>
+        public static void AddBalloonClosedHandler(DependencyObject element, RoutedEventHandler handler)
+        {
+            RoutedEventHelper.AddHandler(element, BalloonClosedEvent, handler);
+        }
+
+        /// <summary>
+        /// Removes a handler for the BalloonClosed attached event
+        /// </summary>
+        /// <param name="element">UIElement or ContentElement that listens to the event</param>
+        /// <param name="handler">Event handler to be removed</param>
+        public static void RemoveBalloonClosedHandler(DependencyObject element, RoutedEventHandler handler)
+        {
+            RoutedEventHelper.RemoveHandler(element, BalloonClosedEvent, handler);
+        }
+
+        /// <summary>
+        /// A static helper method to raise the BalloonClosed event on a target element.
+        /// </summary>
+        /// <param name="target">UIElement or ContentElement on which to raise the event</param>
+        /// <param name="source">The <see cref="TaskbarIcon"/> instance that manages the balloon.</param>
+        internal static RoutedEventArgs RaiseBalloonClosedEvent(DependencyObject target, TaskbarIcon source)
+        {
+            if (target == null) return null;
+
+            RoutedEventArgs args = new RoutedEventArgs(BalloonClosedEvent, source);
+            RoutedEventHelper.RaiseEvent(target, args);
+            return args;
+        }
+
+        #endregion
+
         //ATTACHED PROPERTIES
 
         #region ParentTaskbarIcon

--- a/src/NotifyIconWpf/TaskbarIcon.cs
+++ b/src/NotifyIconWpf/TaskbarIcon.cs
@@ -317,6 +317,8 @@ namespace Hardcodet.Wpf.TaskbarNotification
                     // close the popup
                     popup.IsOpen = false;
 
+                    RaiseBalloonClosedEvent(element, this);
+
                     // remove the reference of the popup to the balloon in case we want to reuse
                     // the balloon (then added to a new popup)
                     popup.Child = null;


### PR DESCRIPTION
Add new `BalloonClosed` event which will be called after the Popup is set to false for a custom Balloon.

Closes #36 
