### PR TITLE
Fix double execution of LeftClickCommand

### DIFF
--- a/src/NotifyIconWpf/Interop/WindowMessageSink.cs
+++ b/src/NotifyIconWpf/Interop/WindowMessageSink.cs
@@ -251,9 +251,9 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                     MouseEventReceived?.Invoke(MouseEvent.IconLeftMouseDown);
                     break;
 
-                case WindowsMessages.NIN_SELECT:
-                    //Sent when the icon is selected with the left mouse button.
-                case WindowsMessages.WM_LBUTTONUP:
+                case WindowsMessages.NIN_SELECT when Version == NotifyIconVersion.Vista:
+                    // Sent when the icon is selected with the left mouse button.
+                case WindowsMessages.WM_LBUTTONUP when Version != NotifyIconVersion.Vista:
                     if (!isDoubleClick)
                     {
                         MouseEventReceived?.Invoke(MouseEvent.IconLeftMouseUp);


### PR DESCRIPTION
This PR fixes an issue where the `LeftClickCommand` was executed twice. The redundant handling of the `WM_LBUTTONUP` message caused the command to be triggered multiple times. By removing the `WM_LBUTTONUP` message handling, the `LeftClickCommand` is now executed only once when the notification icon is clicked, also ensuring the correct behavior with `NoLeftClickDelay` enabled.