### PR TITLE
Fix context menu position acording to dpi setting

### DIFF
--- a/src/NotifyIconWpf/Interop/WindowMessageSink.cs
+++ b/src/NotifyIconWpf/Interop/WindowMessageSink.cs
@@ -240,7 +240,7 @@ namespace Hardcodet.Wpf.TaskbarNotification.Interop
                     {
                         X = (short)((nint)wParam & 0xFFFF),
                         Y = (short)((nint)wParam >> 16 & 0xFFFF)
-                    });
+                    }.ScaleWithDpi());
                     break;
 
                 case WindowsMessages.WM_MOUSEMOVE:


### PR DESCRIPTION
With this fix, the context menu position now scales correctly with the DPI settings. 
This should resolve the context menu position issue mentioned in #113